### PR TITLE
fix npm install error by lit-scss-loader version & install @babel/plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,8 @@
       }
     ]
   ],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-private-methods"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
         "@babel/preset-env": "^7.10.4",
         "@lit-labs/task": "^2.0.0",
         "@simonwep/selection-js": "^2.1.1",
@@ -42,7 +43,7 @@
         "json-loader": "^0.5.7",
         "lit": "^2.2.7",
         "lit-html": "^2.2.6",
-        "lit-scss-loader": "^1.1.0",
+        "lit-scss-loader": "^2.0.1",
         "mini-css-extract-plugin": "^2.6.0",
         "minimist": "^1.2.6",
         "popper.js": "^1.16.1",
@@ -94,9 +95,9 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -105,28 +106,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
-      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.4.tgz",
+      "integrity": "sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
-      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.4.tgz",
+      "integrity": "sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.3",
-        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
+        "@babel/helper-compilation-targets": "^7.21.4",
         "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.3",
+        "@babel/parser": "^7.21.4",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.3",
-        "@babel/types": "^7.21.3",
+        "@babel/traverse": "^7.21.4",
+        "@babel/types": "^7.21.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -160,11 +161,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
-      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
+      "integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
       "dependencies": {
-        "@babel/types": "^7.21.3",
+        "@babel/types": "^7.21.4",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -210,12 +211,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.4.tgz",
+      "integrity": "sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==",
       "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/compat-data": "^7.21.4",
+        "@babel/helper-validator-option": "^7.21.0",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
@@ -228,9 +229,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.0.tgz",
-      "integrity": "sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.4.tgz",
+      "integrity": "sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -249,9 +250,9 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.0.tgz",
-      "integrity": "sha512-N+LaFW/auRSWdx7SHD/HiARwXQju1vXTW4fKr4u5SgBUTm51OKEjKgj+cs00ggW3kEvNqwErnlwuq7Y3xBe4eg==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.4.tgz",
+      "integrity": "sha512-M00OuhU+0GyZ5iBBN9czjugzWrEq2vDpf/zCYHxxf93ul/Q5rv+a5h+/+0WnI1AebHNVtl5bFV0qsJoH23DbfA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "regexpu-core": "^5.3.1"
@@ -333,11 +334,11 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.21.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -575,9 +576,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
-      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
+      "integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -908,11 +909,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
-      "integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.21.4.tgz",
+      "integrity": "sha512-l9xd3N+XG4fZRxEP3vXdK6RW7vN1Uf5dxzRC/09wV86wqZ/YYQooBIGNsiRdfNR3/q2/5pPzV4B54J/9ctX5jw==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -941,6 +942,20 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.21.4.tgz",
+      "integrity": "sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1041,11 +1056,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
-      "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.21.4.tgz",
+      "integrity": "sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1562,30 +1577,30 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
-      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.21.4.tgz",
+      "integrity": "sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==",
       "dependencies": {
-        "@babel/compat-data": "^7.20.1",
-        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/compat-data": "^7.21.4",
+        "@babel/helper-compilation-targets": "^7.21.4",
         "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/helper-validator-option": "^7.21.0",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.20.7",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.7",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
-        "@babel/plugin-proposal-class-static-block": "^7.18.6",
+        "@babel/plugin-proposal-class-static-block": "^7.21.0",
         "@babel/plugin-proposal-dynamic-import": "^7.18.6",
         "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/plugin-proposal-json-strings": "^7.18.6",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.20.7",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/plugin-proposal-numeric-separator": "^7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
         "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
-        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-optional-chaining": "^7.21.0",
         "@babel/plugin-proposal-private-methods": "^7.18.6",
-        "@babel/plugin-proposal-private-property-in-object": "^7.18.6",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1602,40 +1617,40 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.18.6",
-        "@babel/plugin-transform-async-to-generator": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.20.7",
+        "@babel/plugin-transform-async-to-generator": "^7.20.7",
         "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
-        "@babel/plugin-transform-block-scoping": "^7.20.2",
-        "@babel/plugin-transform-classes": "^7.20.2",
-        "@babel/plugin-transform-computed-properties": "^7.18.9",
-        "@babel/plugin-transform-destructuring": "^7.20.2",
+        "@babel/plugin-transform-block-scoping": "^7.21.0",
+        "@babel/plugin-transform-classes": "^7.21.0",
+        "@babel/plugin-transform-computed-properties": "^7.20.7",
+        "@babel/plugin-transform-destructuring": "^7.21.3",
         "@babel/plugin-transform-dotall-regex": "^7.18.6",
         "@babel/plugin-transform-duplicate-keys": "^7.18.9",
         "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
-        "@babel/plugin-transform-for-of": "^7.18.8",
+        "@babel/plugin-transform-for-of": "^7.21.0",
         "@babel/plugin-transform-function-name": "^7.18.9",
         "@babel/plugin-transform-literals": "^7.18.9",
         "@babel/plugin-transform-member-expression-literals": "^7.18.6",
-        "@babel/plugin-transform-modules-amd": "^7.19.6",
-        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
+        "@babel/plugin-transform-modules-amd": "^7.20.11",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@babel/plugin-transform-modules-systemjs": "^7.20.11",
         "@babel/plugin-transform-modules-umd": "^7.18.6",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.20.5",
         "@babel/plugin-transform-new-target": "^7.18.6",
         "@babel/plugin-transform-object-super": "^7.18.6",
-        "@babel/plugin-transform-parameters": "^7.20.1",
+        "@babel/plugin-transform-parameters": "^7.21.3",
         "@babel/plugin-transform-property-literals": "^7.18.6",
-        "@babel/plugin-transform-regenerator": "^7.18.6",
+        "@babel/plugin-transform-regenerator": "^7.20.5",
         "@babel/plugin-transform-reserved-words": "^7.18.6",
         "@babel/plugin-transform-shorthand-properties": "^7.18.6",
-        "@babel/plugin-transform-spread": "^7.19.0",
+        "@babel/plugin-transform-spread": "^7.20.7",
         "@babel/plugin-transform-sticky-regex": "^7.18.6",
         "@babel/plugin-transform-template-literals": "^7.18.9",
         "@babel/plugin-transform-typeof-symbol": "^7.18.9",
         "@babel/plugin-transform-unicode-escapes": "^7.18.10",
         "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.21.4",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -1650,13 +1665,13 @@
       }
     },
     "node_modules/@babel/preset-flow": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.18.6.tgz",
-      "integrity": "sha512-E7BDhL64W6OUqpuyHnSroLnqyRTcG6ZdOBl1OKI/QK/HJfplqK/S3sq1Cckx7oTodJ5yOXyfw7rEADJ6UjoQDQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.21.4.tgz",
+      "integrity": "sha512-F24cSq4DIBmhq4OzK3dE63NHagb27OPE3eWR+HLekt4Z3Y5MzIIUGF3LlLgV0gN8vzbDViSY7HnrReNVCJXTeA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-validator-option": "^7.18.6",
-        "@babel/plugin-transform-flow-strip-types": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-option": "^7.21.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1681,13 +1696,15 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.21.0.tgz",
-      "integrity": "sha512-myc9mpoVA5m1rF8K8DgLEatOYFDpwC+RkMkjZ0Du6uI62YvDe8uxIEYVs/VCdSJ097nlALiU/yBC7//3nI+hNg==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.21.4.tgz",
+      "integrity": "sha512-sMLNWY37TCdRH/bJ6ZeeOH1nPuanED7Ai9Y/vH31IPqalioJ6ZNFUWONsakhv4r4n+I6gm5lmoE0olkgib/j/A==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-validator-option": "^7.21.0",
-        "@babel/plugin-transform-typescript": "^7.21.0"
+        "@babel/plugin-syntax-jsx": "^7.21.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@babel/plugin-transform-typescript": "^7.21.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1866,18 +1883,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
-      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
+      "integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.3",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.3",
-        "@babel/types": "^7.21.3",
+        "@babel/parser": "^7.21.4",
+        "@babel/types": "^7.21.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1886,9 +1903,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
-      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
+      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -1927,9 +1944,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz",
-      "integrity": "sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -1941,29 +1958,32 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
-      "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
-      "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.0",
+        "espree": "^9.5.1",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -2004,9 +2024,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
+      "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -2117,14 +2137,14 @@
       "dev": true
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz",
-      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz",
+      "integrity": "sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong=="
     },
     "node_modules/@lit-labs/task": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/task/-/task-2.0.0.tgz",
-      "integrity": "sha512-r567PcR6Koq7DoBwdnMWxyO3Ww9BkJshGmuviwhCcNRATSgDx/O6SEZ95oBfgxN6hKyoYT3lbtRzMPKhKRHUow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/task/-/task-2.1.0.tgz",
+      "integrity": "sha512-T22/3sFQEpOTXlO4Bjpn4oOH/1duhRzbO6rV+eZ1zwr3eqpH8Qmy1H4I8LDfGOHc/GOeFnde2U1Xvji0pxIZeQ==",
       "dependencies": {
         "@lit/reactive-element": "^1.1.0"
       }
@@ -2248,9 +2268,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -2421,9 +2441,9 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.69.0.tgz",
-      "integrity": "sha512-n59Mz6JjgL5SJHne7om22+5RRfDNmM8oQ0NgHvWU44rHcmA/8Byxs28w6Ke2xgJFmLYasEw6hx1bwAATBLaa7w==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.69.2.tgz",
+      "integrity": "sha512-av9vS1SbXxGJvCt4QggrIvS8dr3ZfL6jxrNQGr4cq1wFY/n5ruj0RsXix208c3Zp1Kua3QVOUaJvA+7RdT1VJA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.69.0",
@@ -2436,26 +2456,26 @@
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.69.0.tgz",
-      "integrity": "sha512-TDcrES6POTBrQXDdq7VjlqFYZuZ/eqaxD9K2MUJcRckil+jxpDV0W38lgXE+c8Gjwvqqqce/izkilUgMA+ajFA==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.69.2.tgz",
+      "integrity": "sha512-ipu94QNw8ZKWC+pfie5IyIzVImR5N0PANXkUSfFon5L4aMAtggKpZn7aUv/2Cxn51JsCvjZwkXT7PaJ8RddpxA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.69.0.tgz",
-      "integrity": "sha512-1W5N4wL5I9n4dD6AJ1Bh49kphn+DXmwggUQhwsq7phxey4jiEXUNC9W/CQDXJp0wkFtNE6REn8yks9QGqfkemw==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.69.2.tgz",
+      "integrity": "sha512-JnOPiDvPfNH/6WWVBqBwK0oIHscHECtL1iZDUE9nB4NSbyoV10oulkuhHNAO9BImqtU4rxtWbXyTL1MEuUdHHQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2463,14 +2483,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.69.0.tgz",
-      "integrity": "sha512-D49mduzDwVQJp55+KoT8NozQEUsLMhCxbAnD4iY1E/v4uK7xSqQ3JW/Luunz6DNKWWtcWhgCiehmBwIjVAQN/A==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.69.2.tgz",
+      "integrity": "sha512-SOg9P4rM5Aj2jabt4njmFbZTRMX8/vRHgiDL9vE+uz7s6j64B9QBSFF42j17cEVq6ToqQ7jtu40f1D7K62puQA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2478,12 +2498,12 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.69.0.tgz",
-      "integrity": "sha512-rRo226jITgG6DZNuk1oCuKFhr0giJ6GATyQtaaEmH9bhxB8i1eeES/LolJfo4donyejCb+imJN+L1fQ1N2YOYA==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.69.2.tgz",
+      "integrity": "sha512-8yB4afGBAX+vN5oNRxZMWWS/2G0Q9VUzlL2AOu0Q70FQkscbjQcsb6QX9LbHFMrwi3MgOgE0ewMncpcwskuoXA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2491,14 +2511,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.69.0.tgz",
-      "integrity": "sha512-koLHh4TS3RtrWxcYX/tZobgnwUbjiFLOESiqe0FYvs82LXNwr+dveM8Umj89ACjpCd0Pq2J+5yvfNyvuIa6WFw==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.69.2.tgz",
+      "integrity": "sha512-RPazXv7L37vrdqHeFy/ZrKVz+vnVOqEFrHFefaq2L5avnzInVTRsTJm+61q0jqnckozz426Gbg5wJgq+Yvpbqg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2506,14 +2526,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.69.0.tgz",
-      "integrity": "sha512-OaEBBrgoDfqMPnZ0NCfg5HUJJ/V6XJ1AZ6OTW1AfJTqErLxYTgdNv52lYXKLiKkyLiH5olBBnPEKPPLg+DwUKQ==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.69.2.tgz",
+      "integrity": "sha512-pQQE85xjv+UaObQzkhpOPochQ8GhWETAUuzDxHrgKmw20Ca03QAC7RV3tbSnkIbI5cy9wpb4gRM0T5/PzZnBYA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2521,13 +2541,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.69.0.tgz",
-      "integrity": "sha512-rKgEd/k0MNV93DhwZ6yfUaIjbs6RfS9xB3QN9M6Lx5ZJktxNGAdpS/c3WEb5jBOpkQIJ6MaNI67Q0ZHHJTlrng==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.69.2.tgz",
+      "integrity": "sha512-OroXRC+Q1btrpuQ3+ZbMi9XGYiab3YQMg/Rx1wpszbW5C5IPtaa2/FtMcBGYWR5IIdxi+bAT8itbMBGSCcz/Ew==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2535,13 +2555,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.69.0.tgz",
-      "integrity": "sha512-l5g4K09I4znwTcXbkBaE4JKmvEQ7Q831hzpBWZimcnUGrC8/nJ7eYUc04bjgbdDZd37B0zEzRn6w92ax7Hi2Fg==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.69.2.tgz",
+      "integrity": "sha512-2yyUmdbvkDnZuOGDduvlp4dtLL/8a1PCR+Ajk9+PR4ZTdbMFtZWcr/knGc33Rtr8eXQwd4NPypFHhTLCEHiGwg==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2549,74 +2569,74 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.69.0.tgz",
-      "integrity": "sha512-oi52u6rmLrE+iXOk5wlx1NRXHd0NtGsxF1G+g2JTtC0oh5ETrj5fMGwMQwcBqYGTj3Y6vPJMkvVyaC46KUKg0Q==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.69.2.tgz",
+      "integrity": "sha512-qVL8JrnsjuD3uS1PTNoBTKd5YXPs2SfxRGyKwcmrUXFS+jJmbyYF04xmCgXkwI6TZYjY6KlNb8vmOt4Xr8FqnA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.69.0.tgz",
-      "integrity": "sha512-bqgf+iHK3qrANJ5zrQJ+BoWrIftL4YhCfZyE/aWwnGW1BKdB4uGC94rx9DHhS8ZfNPz7AnW+ki6ISXpYOD8uyw==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.69.2.tgz",
+      "integrity": "sha512-vMWfQiXcSeo9XSJJ1Yny4BAUw/3RBbBTsPBbNSsnMtpcDhBbodxdko1CeYkGc8sKM0QyeTFPJuiVhb3kGidbcQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.69.0.tgz",
-      "integrity": "sha512-3b1nGsbFh6DAUDB9plQE5iyqOE37DZS/X34Hr+5ENiq7DFA/19UYeUSJQfU+kWjtFzRDHBRluPo38nHdGnh4gg==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.69.2.tgz",
+      "integrity": "sha512-/WDVzOcGFxSgBVCiXHVnfiOeYIWtn2RG/Bnn8leUmWRN9oRBiCS3Lh60qWVpvs4BOVntL7SYJnC+buicKD1iJA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.69.0.tgz",
-      "integrity": "sha512-JEuZw04wdtbn1WFkavB9Yn8MNAWtfUdlD6naa/Z4CL0iUOhC5BzG9dUfe6gn+Z+xtFRHm3MHMh9B6Xdr3MWDBg==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.69.2.tgz",
+      "integrity": "sha512-qr5epdayokdYyPIJITyqWmUxdknhgPbXhWpSxdEvM8UHgtyutvvvFenFM5pXD1ft8I/uv9oj2WNZxCH2mpsR1g==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.69.0.tgz",
-      "integrity": "sha512-wNSYD9FU31aSBnCCp3Nt2ZZVAdu1LGGWmlLKmcOx7SXi79F1E+T6RtqyoLa0VBGKPVEwDtaH8kWRsZzXpUZVvQ==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.69.2.tgz",
+      "integrity": "sha512-mRXrf9bz2lxf9DY2n2WkB3GlQ8MXRqKBwpXLwjDqqve25Wf6X8QNzfz5ykYORQMuyDIgPq/8aMet7yjHRNtcUQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.69.0",
-        "@swagger-api/apidom-core": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2627,74 +2647,74 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.69.0.tgz",
-      "integrity": "sha512-aSNFJ4he67c5Vz9+FbKKnJzy9JdmSDqzeog8CTiLI8TFrCvj9KQns68NbemyxHHc7uH9TcOwXq3WbXgXSWv60A==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.69.2.tgz",
+      "integrity": "sha512-NGOX9NcrAy1RX1f+uA2rLZbgVWte6O4HRVk0eVjuR3NKjJzuXFdfaYJUpT8IGJx2cW6HsQtJU+BpR+LMfZnM9A==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.69.0.tgz",
-      "integrity": "sha512-7TCnTTKMVTyDiX7MKhphmqUaoKtWLOgKCaPEtBRFgd94yOkobWBKw7yG6G+0rdsCIb4Q9AFcL39eUDh5yI45/w==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.69.2.tgz",
+      "integrity": "sha512-agafo94Uru42/nnydZ2wEt3ENAB6LWAd9l4d8wZL0ifAkjx8fv8rfH601LpFBQq3iD2DlGm0+UpFZXLfBuuQbQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.69.0.tgz",
-      "integrity": "sha512-mrKLsNMsJr5Z4cUDO4v5vt59uGGWfLL36hTuSKcqO9IH/3nziPrYJ7Kd4VdiJaQYqFuUQCEG7A2pOZfkpbR1KA==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.69.2.tgz",
+      "integrity": "sha512-p7Wqk7vCgh9mkXQmk9I/uXri2+1MLCQ14NHfrVowey4ntH4LzBf0NtvxgfCryzzLb2RpdUwIxoh+uf4ibTzyyA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.69.0.tgz",
-      "integrity": "sha512-tEyNhlGoQ7/CnC0K3NqBWfhi90U+5fFDl7Z2PyV/+fRG1F0okAoHwp9+Q3/BieWdiZ5OChX8yxwOdq1kJ2+TTQ==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.69.2.tgz",
+      "integrity": "sha512-Dq914JCnOqmRl6DyxeaP91MlZvIn62hax4RsANeiHIm2ICwwCQLNM9RNUkWq3iimHZpvTz+etM3QkKMakXUnqQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.69.0.tgz",
-      "integrity": "sha512-wfvFXg9xSz89hg/MRd1u6ESUb2UQmVJVIS2wWZwi1UXN9+F3Yh2l8RB5JchJYb5bqu2HX1ZYJ6FxG3dQTQICyQ==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.69.2.tgz",
+      "integrity": "sha512-5sWKGF/phSd+kvOD8xfB2W26QeN2U6LOoLy6eYvf8DP5q4doiLoEcVIunpcVjl04IWVet+VFH9XFGEMlKk7qKQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.69.0",
-        "@swagger-api/apidom-core": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -2705,35 +2725,35 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.69.0.tgz",
-      "integrity": "sha512-Sc3My/qTa90ofWXRaULkQ2oCUlgUCTbPN209jk/Lg0cywPTgeVEVn7Awpp2ftxl007uPPr2PwUzn/K6zzj+gyg==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.69.2.tgz",
+      "integrity": "sha512-aJsgtCP71t8a+frS+qn1FW9MqjjK60c3AnB2G3cUXGVwzmEPEkvBFF0LGlPmHftVvzzBvI7AsMC7+HZPM/t7rQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.0",
+        "@swagger-api/apidom-core": "^0.69.2",
         "@types/ramda": "=0.28.23",
         "axios": "=1.3.4",
-        "minimatch": "=7.3.0",
+        "minimatch": "=7.4.3",
         "process": "=0.11.10",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
         "stampit": "=4.3.2"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^0.69.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.69.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.0"
+        "@swagger-api/apidom-json-pointer": "^0.69.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.69.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/axios": {
@@ -2755,9 +2775,9 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.3.0.tgz",
-      "integrity": "sha512-WaMDuhKa7a6zKiwplR1AOz+zGvJba24k5VU1Cy6NhEguavT2YRlHxuINUgTas4wiS6fwBpYq4TcA1XIECSntyw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
+      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2874,9 +2894,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.2.tgz",
-      "integrity": "sha512-EMpxUyystd3uZVByZap1DACsMXvb82ypQnGn89e1Y0a+LYu3JJscUd/gqhRsVFDkaD2MIiWo0MT8EfXr3DGRKw==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2971,9 +2991,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/mdast": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-      "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
+      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
       "dev": true,
       "dependencies": {
         "@types/unist": "*"
@@ -2996,9 +3016,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw=="
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3039,9 +3059,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "version": "18.0.33",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.33.tgz",
+      "integrity": "sha512-sHxzVxeanvQyQ1lr8NSHaj0kDzcNiGpILEVt69g9S31/7PfMvNCKLKcsHw4lYKjs3cGNJjXSP4mYzX43QlnjNA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3089,9 +3109,9 @@
       "dev": true
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -4517,9 +4537,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/bonjour-service": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
-      "integrity": "sha512-LVRinRB3k1/K0XzZ2p58COnWvkQknIY6sf0zF2rpErvcJXpMBttEPQSxK+HEXSS9VmpZlDoDnQWv8ftJT20B0Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
+      "integrity": "sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==",
       "dev": true,
       "dependencies": {
         "array-flatten": "^2.1.2",
@@ -5099,9 +5119,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001467",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001467.tgz",
-      "integrity": "sha512-cEdN/5e+RPikvl9AHm4uuLXxeCNq8rFsQ+lPHTfe/OtypP3WwnVVbjn+6uBV7PaFL6xUFzTh+sSCOz1rKhcO+Q==",
+      "version": "1.0.30001474",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
+      "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -5110,6 +5130,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -5482,9 +5506,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.8.0.tgz",
+      "integrity": "sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==",
       "engines": {
         "node": ">=6"
       },
@@ -6258,9 +6282,9 @@
       "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.29.1.tgz",
-      "integrity": "sha512-QmchCua884D8wWskMX8tW5ydINzd8oSJVx38lx/pVkFGqztxt73GYre3pm/hyYq8bPf+MW5In4I/uRShFDsbrA==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.0.tgz",
+      "integrity": "sha512-P5A2h/9mRYZFIAP+5Ab8ns6083IyVpSclU74UNvbGVQ8VM7n3n3/g2yF3AkKQ9NXz2O+ioxLbEWKnDtgsFamhg==",
       "dependencies": {
         "browserslist": "^4.21.5"
       },
@@ -6270,9 +6294,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.29.1.tgz",
-      "integrity": "sha512-4En6zYVi0i0XlXHVz/bi6l1XDjCqkKRq765NXuX+SnaIatlE96Odt5lMLjdxUiNI1v9OXI5DSLWYPlmTfkTktg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.0.tgz",
+      "integrity": "sha512-+2KbMFGeBU0ln/csoPqTe0i/yfHbrd2EUhNMObsGtXMKS/RTtlkYyi+/3twLcevbgNR0yM/r0Psa3TEoQRpFMQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -6398,9 +6422,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
+      "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
       "engines": {
         "node": "^10 || ^12 || >=14"
       },
@@ -6801,9 +6825,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/csv-loader": {
       "version": "3.0.5",
@@ -7220,9 +7244,9 @@
       "optional": true
     },
     "node_modules/deparam.js": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/deparam.js/-/deparam.js-3.0.6.tgz",
-      "integrity": "sha512-UQHVDeAYFxTvaDl3ATH7tDySjjxsNiogwc+nUPckFD0AHC6AeirvpzVa/yh9GKNszk5Ut2pb2jZJNBbOKTebnQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/deparam.js/-/deparam.js-3.0.7.tgz",
+      "integrity": "sha512-zm4pDfvPU8uZns8dAit+2K/RdfpUidd82hhTOgSSTBA4ljMqHJPqCcmgI/qa4ddYGoNRM3zVT/+XPHSl2if5Sg==",
       "dependencies": {
         "is-number": "^7.0.0",
         "is-object": "^1.0.2"
@@ -7305,9 +7329,9 @@
       "dev": true
     },
     "node_modules/dns-packet": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
-      "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.5.0.tgz",
+      "integrity": "sha512-USawdAUzRkV6xrqTjiAEp6M9YagZEzWcSUaZTcIFAiyQWW1SoI6KyId8y2+/71wbgHKQAKd+iupLv4YvEwYWvA==",
       "dev": true,
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
@@ -7393,9 +7417,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.10.tgz",
-      "integrity": "sha512-o7Fg/AgC7p/XpKjf/+RC3Ok6k4St5F7Q6q6+Nnm3p2zGWioAY6dh0CbbuwOhH2UcSzKsdniE/YnE2/92JcsA+g=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.1.tgz",
+      "integrity": "sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -7556,9 +7580,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.332",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.332.tgz",
-      "integrity": "sha512-c1Vbv5tuUlBFp0mb3mCIjw+REEsgthRgNE8BlbEDKmvzb8rxjcVki6OkQP83vLN34s0XCxpSkq7AZNep1a6xhw=="
+      "version": "1.4.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.352.tgz",
+      "integrity": "sha512-ikFUEyu5/q+wJpMOxWxTaEVk2M1qKqTGKKyfJmod1CPZxKfYnxVS41/GCBQg21ItBpZybyN8sNpRqCUGm+Zc4Q=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7783,14 +7807,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.1",
-        "@eslint/js": "8.36.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.37.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -7801,8 +7825,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.5.0",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -7839,9 +7863,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
-      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7883,11 +7907,14 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/estraverse": {
@@ -7943,13 +7970,13 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7959,11 +7986,14 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -8807,9 +8837,9 @@
       "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash."
     },
     "node_modules/flow-parser": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.202.0.tgz",
-      "integrity": "sha512-ZiXxSIXK3zPmY3zrzCofFonM2T+/3Jz5QZKJyPVtUERQEJUnYkXBQ+0H3FzyqiyJs+VXqb/UNU6/K6sziVYdxw==",
+      "version": "0.203.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.203.1.tgz",
+      "integrity": "sha512-Nw2M8MPP/Zb+yhvmPDEjzkCXLtgyWGKXZjAYOVftm+wIf3xd4FKa7nRI9v67rODs0WzxMbPc8IPs/7o/dyxo/Q==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -9962,9 +9992,9 @@
       }
     },
     "node_modules/html-tags": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
-      "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -11240,9 +11270,9 @@
       "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
     },
     "node_modules/js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -11661,41 +11691,42 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lit": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.6.1.tgz",
-      "integrity": "sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.1.tgz",
+      "integrity": "sha512-t1cVWUVQj+ucdx16QPvqzyHWYTj/bvlv6vRCUuZ5T/dA4W2Ui4a4tz7uJ1IhoTb9rKe3pTJiWmoN2GJGGteszw==",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.2.0",
-        "lit-html": "^2.6.0"
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
-      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.1.tgz",
+      "integrity": "sha512-Gl+2409uXWbf7n6cCl7Kzasm7zjT9xmdwi2BhLNi70sRKAgRkqueDu5mSIH3hPYMM0/vqBCdPXod3NbGkRA2ww==",
       "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.7.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.6.1.tgz",
-      "integrity": "sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.1.tgz",
+      "integrity": "sha512-san46v7VXK6+2RXS4yveQYFUf9CoO/1bcNb0NibxLoTqlP48vs+l28tRPFDYcXGKWm0XoqcDuCC6mxIs8Jj3Zw==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lit-scss-loader": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/lit-scss-loader/-/lit-scss-loader-1.1.1.tgz",
-      "integrity": "sha512-fZx72hHwZbtkRqb9d51NjGjcs4eBP8Gc2OyxycF7OSXe/Q9QtCGODbwA14z8ux0YfGKV0hBhYkYQd3qODU2daA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lit-scss-loader/-/lit-scss-loader-2.0.1.tgz",
+      "integrity": "sha512-2PvmHuklfZx+OgudhU2zH4SrKyPdzQ9eOQsYoxGEga10dcAwmiMx/6UjOdI13i/BHxcElOqSmTkJ4hBxZrO7dQ==",
       "dependencies": {
         "clean-css": "^4.2.1"
       },
       "peerDependencies": {
-        "webpack": "^4.29.5"
+        "webpack": "^5.37.1"
       }
     },
     "node_modules/load-json-file": {
@@ -12980,9 +13011,15 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -14068,9 +14105,9 @@
       }
     },
     "node_modules/papaparse": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.0.tgz",
-      "integrity": "sha512-ZBQABWG09p+u8rFoJVl/GhgxZ5zy9Zh1Lu/LVc7VX5T4nljjC14/YTcpebYwqP218B9X307eBOP7Tuhoqv7v7w=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -21823,9 +21860,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.59.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.3.tgz",
-      "integrity": "sha512-QCq98N3hX1jfTCoUAsF3eyGuXLsY7BCnCEg9qAact94Yc21npG2/mVOqoDvE0fCbWDqiM4WlcJQla0gWG2YlxQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
+      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -22382,20 +22419,12 @@
       }
     },
     "node_modules/shush": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shush/-/shush-1.0.2.tgz",
-      "integrity": "sha512-dA7YOFK3a2Ra2SVOucZIDi6qjllTEw3ri7eexmyxyJCYFpYZe0Ja4ZWUqX0NG6DKkC2rw1FEtsrCakERwGQR2g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/shush/-/shush-1.0.3.tgz",
+      "integrity": "sha512-aUzxIbRRuTTVOD1GADL3WyBonY/JX29eIArCDM40wDrXFSUzM2XCkI3zVlA11K+2CTniHTE/znoYZh/ig81acg==",
       "dependencies": {
         "caller": "^1.1.0",
-        "strip-json-comments": "~2.0.1"
-      }
-    },
-    "node_modules/shush/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "engines": {
-        "node": ">=0.10.0"
+        "strip-json-comments": "^3.1.1"
       }
     },
     "node_modules/side-channel": {
@@ -23472,15 +23501,15 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.2.tgz",
-      "integrity": "sha512-oBR6VtD99yJOY8W3vf1h8zU91H5UpwUk2trSL4xzZIzChWtlaOMyWh+/GyUGgDCmQY4B1E4qTgAD/kFQ4dFnnA==",
+      "version": "3.19.6",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.6.tgz",
+      "integrity": "sha512-fd0XaoKz3lgs6viKkqK+o8QyrOOZULD4tLcUd8wEfsVBjJIAks2Qa1AhGUr87mfCWZw0Z9OXItWF9T477rRXzw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.13",
-        "@swagger-api/apidom-core": "=0.69.0",
-        "@swagger-api/apidom-json-pointer": "=0.69.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "=0.69.0",
-        "@swagger-api/apidom-reference": "=0.69.0",
+        "@swagger-api/apidom-core": ">=0.69.2 <1.0.0",
+        "@swagger-api/apidom-json-pointer": ">=0.69.2 <1.0.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=0.69.2 <1.0.0",
+        "@swagger-api/apidom-reference": ">=0.69.2 <1.0.0",
         "cookie": "~0.5.0",
         "cross-fetch": "^3.1.5",
         "deepmerge": "~4.3.0",
@@ -23512,9 +23541,9 @@
       }
     },
     "node_modules/swagger-ui": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-4.18.1.tgz",
-      "integrity": "sha512-KMG/Mg+b7oPtBOlpx9abbmU6Rm86kiVUvvpR3EkplBz0CSnseuQZN2XdDZKD7QsvM78NkUhn53y5EZCb+4rd1g==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-4.18.2.tgz",
+      "integrity": "sha512-0IFzqYLBZ2BQYOW5lbDzF9BZl2o2/IDXYhErsazUXHWIXLkMDCxsgd+ocdj4AGtUO3gdGk4QZgHkJwZb/OGbgg==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.18.9",
@@ -23523,7 +23552,7 @@
         "classnames": "^2.3.1",
         "css.escape": "1.5.1",
         "deep-extend": "0.6.0",
-        "dompurify": "=2.3.10",
+        "dompurify": "=3.0.1",
         "ieee754": "^1.2.1",
         "immutable": "^3.x.x",
         "js-file-download": "^0.4.12",
@@ -23548,7 +23577,7 @@
         "reselect": "^4.1.5",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.19.1",
+        "swagger-client": "^3.19.5",
         "url-parse": "^1.5.8",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -23822,9 +23851,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
-      "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
+      "version": "5.16.8",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.8.tgz",
+      "integrity": "sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -25427,9 +25456,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.12.0.tgz",
-      "integrity": "sha512-XRN9YRnvOj3TQQ5w/0pR1y1xDcVnbWtNkTri46kuEbaWUPTHsWUvOyAAI7PZHLY+hsFki2kRltJjKMw7e+IiqA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.2.tgz",
+      "integrity": "sha512-5i6TrGBRxG4vnfDpB6qSQGfnB6skGBXNL5/542w2uRGLimX6qeE5BQMLrzIC3JYV/xlGOv+s+hTleI9AZKUQNw==",
       "dev": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
@@ -25477,6 +25506,9 @@
         "webpack": "^4.37.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        },
         "webpack-cli": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:staged": "lint-staged"
   },
   "dependencies": {
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/preset-env": "^7.10.4",
     "@lit-labs/task": "^2.0.0",
     "@simonwep/selection-js": "^2.1.1",
@@ -51,7 +52,7 @@
     "json-loader": "^0.5.7",
     "lit": "^2.2.7",
     "lit-html": "^2.2.6",
-    "lit-scss-loader": "^1.1.0",
+    "lit-scss-loader": "^2.0.1",
     "mini-css-extract-plugin": "^2.6.0",
     "minimist": "^1.2.6",
     "popper.js": "^1.16.1",


### PR DESCRIPTION
packageに関して２点の修正を行いました。
- `npm install` を行うとerrorが表示されてしまうため、`lit-scss-loader`のversionを上げました。
- webpackのerrorでjavascriptの#でのプライベートクラスをこのままでは使用できないと言われたので、`@babel/plugin-proposal-private-methods`をinstallしました。

よろしくお願いいたします。