### PR TITLE
change example of search by tgvid to tgv56616325

### DIFF
--- a/app/frontend/javascripts/classes/SimpleSearchView.js
+++ b/app/frontend/javascripts/classes/SimpleSearchView.js
@@ -19,7 +19,7 @@ const EXAMPLES = (() => {
         },
         {
           key: 'TogoVar',
-          value: 'tgv421843'
+          value: 'tgv56616325'
         },
         {
           key: 'Position(GRCh37/hg19)',
@@ -54,7 +54,7 @@ const EXAMPLES = (() => {
         },
         {
           key: 'TogoVar',
-          value: 'tgv421843'
+          value: 'tgv56616325'
         },
         {
           key: 'Position(GRCh38)',


### PR DESCRIPTION
Changed example of search by tgvid from tgv421843 to tgv56616325. Variant report pages for it exist at both https://grch37.togovar.org/variant/tgv56616325 and https://grch37.togovar.org/variant/tgv56616325.