### PR TITLE
Add 54kjpn

### DIFF
--- a/app/frontend/views/doc/en/datasets_grch37.pug
+++ b/app/frontend/views/doc/en/datasets_grch37.pug
@@ -83,7 +83,7 @@ article.common-document
           | Japanese Genotype-phenotype Archive (JGA)
         |  /
         |
-        a.hyper-text.-external(target='_blank', href='https://www.biobank.amed.go.jp/itc/agd/index.html')
+        a.hyper-text.-external(target='_blank', href='https://gr-sharingdbs.biosciencedbc.jp/agd')
           | AMED Genome group sharing Database (AGD)
     section.section
       h3.sectiontitle Other variant frequency datasets
@@ -105,7 +105,7 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads')
+              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads#v2')
                 | Genome Aggregation Database (gnomAD) exomes
             td._align-left WES
             td._align-left Mixed
@@ -119,7 +119,7 @@ article.common-document
             td v2.1.1
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads')
+              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads#v2')
                 | Genome Aggregation Database (gnomAD) genomes
             td._align-left WGS
             td._align-left Mixed
@@ -152,7 +152,7 @@ article.common-document
               | (2017/08/02)
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/202001/downloads/#variant')
+              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-8.3kjpn-20200831-af_snvindelall')
                 | ToMMo #{ GLOBALS.TOMMO_VERSION }KJPN Allele Frequency Panel(#{ GLOBALS.TOMMO_VERSION }KJPN)
             td._align-left WGS
             td._align-left Japanese
@@ -165,7 +165,7 @@ article.common-document
               br
               | (79,359,228)
             td Tohoku Medical Megabank Organization
-            td v202109
+            td v20200831
       p.notice
         | Note: #{ GLOBALS.TOMMO_VERSION }KJPN consists of SNVs (Autosome, chrX(PAR1+PAR2+XTR) and chrMT) and INDELs (Autosome and
         | chrX(PAR1+PAR2+XTR)).
@@ -182,13 +182,13 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
-            td 2022/09/01
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
+            td 2023/09/11
             td Clinical significance of variants
             td NCBI
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.dbcls.jp/colil') Colil
+              a.hyper-text.-external(target='_blank', href='https://ftp.dbcls.jp/colil') Colil
             td Obtained by API
             td Information on citation relationships in life sciences literature
             td DBCLS
@@ -201,29 +201,36 @@ article.common-document
             td GRC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/')
+              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/docs/file-downloads')
                 | GWAS Catalog
-            td 2022/09/16
+            td 2023/09/05
             td Catalog of human genome-wide association studies
             td NHGRI-EBI
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.ebi.ac.uk/pub/databases/genenames/new/tsv/hgnc_complete_set.txt')
+              a.hyper-text.-external(target='_blank', href='https://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt')
                 | HGNC symbol report
-            td 2022/9/16
+            td 2023/09/05
             td Approved human gene nomenclature and associated gene information
             td HGNC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/LitVar/')
+              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/research/litvar2/api')
                 | LitVar
             td Obtained by API
             td Information on papers in which the names of variants appear
             td NCBI
           tr
             td
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pubmed/')
+                | PubMed
+            td 2023/09/01
+            td Information on papers
+            td NCBI
+          tr
+            td
               a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/lu/PubTatorCentral/') PubTator Central
-            td 2022/9/20
+            td 2023/09/03
             td Information on papers in which the names of variants appear
             td NCBI
           tr
@@ -235,8 +242,8 @@ article.common-document
       p.notice
         | Note: TogoVar obtained ClinVar variants from
         |
-        a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/') the VCF file
-        | that contains only variants for which GRCh38 positions were determined.
+        a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/') the VCF file
+        | that contains only variants for which GRCh37 positions were determined.
     section.section
       h3.sectiontitle Tools for data processing
       table.table
@@ -251,7 +258,7 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://samtools.github.io/bcftools/') bcftools
             td
-            td Normalize indels and split multiallelic sites into biallelic variants
+            td Split multiallelic sites into biallelic variants
             td Genome Research Ltd.
           tr
             td
@@ -264,9 +271,10 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/index.html')
                 | Variant Effect Predictor (VEP)
-            td Ensembl release 107
+            td Ensembl release 110
             td
               | Add
+              |
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html#cache_content')
                 | annotations like gene names or consequences
               |  to variants

--- a/app/frontend/views/doc/en/datasets_grch38.pug
+++ b/app/frontend/views/doc/en/datasets_grch38.pug
@@ -145,7 +145,7 @@ article.common-document
             td._align-center
               span(style='margin-left:10px;') 54,302
             td._align-center
-              | TO_BE_FILLED
+              | 262,200,990
             td Tohoku Medical Megabank Organization
             td v20230626
       p.notice

--- a/app/frontend/views/doc/en/datasets_grch38.pug
+++ b/app/frontend/views/doc/en/datasets_grch38.pug
@@ -82,7 +82,7 @@ article.common-document
           | Japanese Genotype-phenotype Archive (JGA)
         |  /
         |
-        a.hyper-text.-external(target='_blank', href='https://www.biobank.amed.go.jp/itc/agd/index.html')
+        a.hyper-text.-external(target='_blank', href='https://gr-sharingdbs.biosciencedbc.jp/agd')
           | AMED Genome group sharing Database (AGD)
     section.section
       h3.sectiontitle Other variant frequency datasets
@@ -102,7 +102,7 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads')
+              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads#v3')
                 | Genome Aggregation Database (gnomAD) genomes
             td._align-left WGS
             td._align-center
@@ -114,7 +114,7 @@ article.common-document
             td._align-center
               | 759,302,267
             td Broad Institute
-            td v3.1.2
+            td v3.1.1
           tr
             td
               a.hyper-text.-external(target='_blank', href='http://www.hgvd.genome.med.kyoto-u.ac.jp/download.html')
@@ -135,7 +135,7 @@ article.common-document
               | (2017/08/02)
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-14kjpn-20211208r2-af_snvindelall')
+              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall')
                 | ToMMo #{ GLOBALS.TOMMO_VERSION }KJPN Allele Frequency Panel(#{ GLOBALS.TOMMO_VERSION }KJPN)
             td._align-left WGS
             td._align-center
@@ -143,13 +143,13 @@ article.common-document
             td._align-center ✔
             td._align-center
             td._align-center
-              span(style='margin-left:10px;') approx. 14,000
+              span(style='margin-left:10px;') 54,302
             td._align-center
-              | 133,757,499
+              | TO_BE_FILLED
             td Tohoku Medical Megabank Organization
-            td v20211208r2
+            td v20230626
       p.notice
-        | Note 2 : #{ GLOBALS.TOMMO_VERSION }KJPN consists of SNVs (Autosome, chrX(PAR1+PAR2+XTR) and chrMT) and INDELs (Autosome and
+        | Note: #{ GLOBALS.TOMMO_VERSION }KJPN consists of SNVs (Autosome, chrX(PAR1+PAR2+XTR) and chrMT) and INDELs (Autosome and
         | chrX(PAR1+PAR2+XTR)).
     section.section
       h3.sectiontitle
@@ -164,13 +164,13 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
-            td 2022/09/01
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
+            td 2023/09/11
             td Clinical significance of variants
             td NCBI
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.dbcls.jp/colil') Colil
+              a.hyper-text.-external(target='_blank', href='https://ftp.dbcls.jp/colil') Colil
             td Obtained by API
             td Information on citation relationships in life sciences literature
             td DBCLS
@@ -178,34 +178,41 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/grc/human/data?asm=GRCh38.p13')
                 | GRCh38.p13
-            td 2019/3/1
+            td 2019/03/01
             td Human genome reference sequence
             td GRC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/')
+              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/docs/file-downloads')
                 | GWAS Catalog
-            td 2022/09/16
+            td 2023/09/05
             td Catalog of human genome-wide association studies
             td NHGRI-EBI
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.ebi.ac.uk/pub/databases/genenames/new/tsv/hgnc_complete_set.txt')
+              a.hyper-text.-external(target='_blank', href='https://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt')
                 | HGNC symbol report
-            td 2022/9/16
+            td 2023/09/05
             td Approved human gene nomenclature and associated gene information
             td HGNC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/LitVar/')
+              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/research/litvar2/api')
                 | LitVar
             td Obtained by API
             td Information on papers in which the names of variants appear
             td NCBI
           tr
             td
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pubmed/')
+                | PubMed
+            td 2023/09/01
+            td Information on papers
+            td NCBI
+          tr
+            td
               a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/lu/PubTatorCentral/') PubTator Central
-            td 2022/9/20
+            td 2023/09/03
             td Information on papers in which the names of variants appear
             td NCBI
           tr
@@ -217,7 +224,7 @@ article.common-document
       p.notice
         | Note: TogoVar obtained ClinVar variants from
         |
-        a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/') the VCF file
+        a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/') the VCF file
         | that contains only variants for which GRCh38 positions were determined.
     section.section
       h3.sectiontitle Tools for data processing
@@ -233,7 +240,7 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://samtools.github.io/bcftools/') bcftools
             td
-            td Normalize indels and split multiallelic sites into biallelic variants
+            td Split multiallelic sites into biallelic variants
             td Genome Research Ltd.
           tr
             td
@@ -246,9 +253,10 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/index.html')
                 | Variant Effect Predictor (VEP)
-            td Ensembl release 107
+            td Ensembl release 110
             td
               | Add
+              |
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html#cache_content')
                 |
                 | annotations like gene names or consequences

--- a/app/frontend/views/doc/en/downloads.pug
+++ b/app/frontend/views/doc/en/downloads.pug
@@ -16,37 +16,79 @@ block content
         h2.title Downloads
       .contents
         section.section
-          p.body TogoVar data is downloadable at the links below.
+          h3.sectiontitle
+            | All variants in TogoVar
           ul
             li
-              a(href='/downloads/gem_j_wga/')
-                | Variant frequencies of GEM Japan Whole Genome Aggregation (GEM-J WGA) panel [VCF format]
-              p
-                | The GEM-J WGA panel is a variant frequency dataset of a Japanese general population, which was
-                | obtained by joint variant calling of whole genome sequence (WGS) data collected from 7,609 individuals
-                | across Japan. The WGS data is also available in a controlled access manner. They are the result of
-                |
-                a.hyper-text.-external(target='_blank', href='https://www.amed.go.jp/en/aboutus/collaboration/ga4gh_gem_japan.html')
-                  | the GEnome Medical alliance Japan (GEM Japan) project.
-                a(href='/doc/datasets/gem_j_wga') [More about the dataset]
-                a(href='/downloads/gem_j_wga/') [Download of the dataset]
+              | Allele frequency
+              ul
+                li
+                  | GRCh38：
+                  a(href='/downloads/release/current/grch38/frequency/vcf') VCF format
+                  |
+                  | |
+                  |
+                  a(href='/downloads/release/current/grch38/frequency/tsv') tab-separated text
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch38/frequency/tsv/README.txt') README
+                  | )
+                li
+                  | GRCh37：
+                  a(href='/downloads/release/current/grch37/frequency/vcf') VCF format
+                  |
+                  | |
+                  |
+                  a(href='/downloads/release/current/grch37/frequency/tsv') tab-separated text
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch37/frequency/tsv/README.txt') README
+                  | )
             li
-              a(href='/downloads/release/current')
-                | Variant frequencies of datasets except GEM-J WGA (i.e. JGA-NGS, JGA-SNP, #{ GLOBALS.TOMMO_VERSION }KJPN, HGVD and gnomAD)
-                | [tab-separated format]
-              p
-                a(href='/doc/datasets/jga_ngs') JGA-NGS
-                |  and
-                |
-                a(href='/doc/datasets/jga_snp') JGA-SNP
-                |  are obtained by aggregating individual-level genomic data that have been registered in
-                |
-                a.hyper-text.-external(target='_blank', href='https://humandbs.biosciencedbc.jp/en/') the NBDC Human Database
-                |  /
-                |
-                a.hyper-text.-external(target='_blank', href='https://www.ddbj.nig.ac.jp/jga/index-e.html')
-                  | Japanese Genotype-phenotype Archive (JGA)
-                | .
-                |
-                a(href='/doc/datasets') [More about the datasets]
-                a(href='/downloads/release/current') [Download of the datasets]
+              | Annotation
+              ul
+                li
+                  | GRCh38：
+                  a(href='/downloads/release/current/grch38/annotation') tab-separated text
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch38/annotation/README.txt') README
+                  | )
+                li
+                  | GRCh37：
+                  a(href='/downloads/release/current/grch37/annotation') tab-separated text
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch37/annotation/README.txt') README
+                  | )
+            p
+            | Last updated：2023/11/7
+            br
+            | The allele frequencies were aggregated by
+            |
+            a(href='/doc/datasets/') dataset
+            | .
+        section.section
+          h3.sectiontitle
+            | Original files from depositors (some of the datasets)
+          ul
+            li
+              | Variant frequencies of GEM Japan Whole Genome Aggregation (GEM-J WGA) panel
+              ul
+                li
+                  | Allele frequencies
+                ul
+                  li
+                    | GRCh38 (liftover from GRCh37)：
+                    a(href='/downloads/gem_j_wga/grch38') VCF format
+                  li
+                    | GRCh37：
+                    a(href='/downloads/gem_j_wga/grch37') VCF format
+            p
+            | Last updated：2021/11/29
+            br
+            | See
+            |
+            a(href='/doc/datasets/gem_j_wga') the GEM-J WGA dataset page
+            |
+            | for more about the dataset.

--- a/app/frontend/views/doc/en/history.pug
+++ b/app/frontend/views/doc/en/history.pug
@@ -16,19 +16,19 @@ block content
         h2.title Update history
       .contents
         section.section
-          h3.sectiontitle 2023/9/26
+          h3.sectiontitle 2023/11/7
           ul.unordered-list
             li
               strong Datasets:
               |
-              | ToMMo 14KJPN was updated to
-              |
+              | ToMMo 14KJPN was updated to ToMMo 54KJPN (
               a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall')
-                | ToMMo 54KJPN Allele Frequency Panel.
+                | ToMMo 54KJPN-SNV/INDEL Allele Frequency Panel (v20230626)
+              | ).
             li
               strong Advanced search:
               |
-              | You can search TogoVar using a list of variant IDs from TogoVar and dbSNP, as well as HGNC gene symbols.
+              | You can search by TogoVar ID (e.g. tgv47264307) or dbSNP refSNP ID (e.g. rs671).
             li
               strong Downloads:
               |

--- a/app/frontend/views/doc/en/history.pug
+++ b/app/frontend/views/doc/en/history.pug
@@ -16,6 +16,27 @@ block content
         h2.title Update history
       .contents
         section.section
+          h3.sectiontitle 2023/9/26
+          ul.unordered-list
+            li
+              strong Datasets:
+              |
+              | ToMMo 14KJPN was updated to
+              |
+              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall')
+                | ToMMo 54KJPN Allele Frequency Panel.
+            li
+              strong Advanced search:
+              |
+              | You can search TogoVar using a list of variant IDs from TogoVar and dbSNP, as well as HGNC gene symbols.
+            li
+              strong Downloads:
+              |
+              | Allele frequencies for all variants are available in
+              |
+              a.hyper-text.-external(href='https://samtools.github.io/hts-specs/VCFv4.4.pdf')
+                | VCF format
+              |  as well as tab-separated format.
           h3.sectiontitle 2023/7/14
           ul.unordered-list
             li

--- a/app/frontend/views/doc/ja/datasets_grch37.pug
+++ b/app/frontend/views/doc/ja/datasets_grch37.pug
@@ -155,8 +155,8 @@ article.common-document
               | (2017/08/02)
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/202001/downloads/#variant')
-                | ToMMo #{ GLOBALS.TOMMO_VERSION }KJPN Allele Frequency Panel(#{ GLOBALS.TOMMO_VERSION }KJPN)
+              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-8.3kjpn-20200831-af_snvindelall')
+                | ToMMo #{ GLOBALS.TOMMO_VERSION }KJPN-SNP/INDEL Allele Frequency Panel(#{ GLOBALS.TOMMO_VERSION }KJPN)
             td._align-left WGS
             td._align-left 日本人
             td._align-center ✔

--- a/app/frontend/views/doc/ja/datasets_grch37.pug
+++ b/app/frontend/views/doc/ja/datasets_grch37.pug
@@ -81,7 +81,7 @@ article.common-document
           | Japanese Genotype-phenotype Archive (JGA)
         |  /
         |
-        a.hyper-text.-external(target='_blank', href='https://www.biobank.amed.go.jp/itc/agd/index.html')
+        a.hyper-text.-external(target='_blank', href='https://gr-sharingdbs.biosciencedbc.jp/agd')
           | AMED Genome group sharing Database (AGD)
         br
         | ∗2：fastq/bam/celファイルやgenotype data一覧など
@@ -108,7 +108,7 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads')
+              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads#v2')
                 | Genome Aggregation Database (gnomAD) exomes
             td._align-left WES
             td._align-left 複数
@@ -122,7 +122,7 @@ article.common-document
             td v2.1.1
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads')
+              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads#v2')
                 | Genome Aggregation Database (gnomAD) genomes
             td._align-left WGS
             td._align-left 複数
@@ -168,9 +168,9 @@ article.common-document
               br
               | (79,359,228)
             td 東北メディカル・メガバンク機構
-            td v202109
+            td v20200831
       p.notice
-        | 注：#{ GLOBALS.TOMMO_VERSION }KJPNの内訳は、SNV (Autosome、chrX(PAR1+PAR2+XTR)、chrMT)とINDEL (Autosome、chrX(PAR1+PAR2+XTR))です。
+        | 注：#{ GLOBALS.TOMMO_VERSION }KJPNの内訳はSNV(Autosome、chrX(PAR1+PAR2+XTR)およびchrMT)ならびにINDEL(AutosomeおよびchrX(PAR1+PAR2+XTR))です。
     section.section
       h3.sectiontitle バリアント頻度以外のデータ
       table.table
@@ -183,7 +183,13 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.dbcls.jp/colil') Colil
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
+            td 2023/09/11
+            td バリアントの臨床的意義
+            td NCBI
+          tr
+            td
+              a.hyper-text.-external(target='_blank', href='https://ftp.dbcls.jp/colil') Colil
             td APIで取得
             td 生命科学分野の文献間の引用関係の情報
             td DBCLS
@@ -196,30 +202,37 @@ article.common-document
             td GRC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/')
+              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/docs/file-downloads')
                 | GWAS Catalog
-            td 2022/09/16
+            td 2023/09/05
             td ゲノムワイド関連解析(GWAS)情報
             td NHGRI-EBI
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.ebi.ac.uk/pub/databases/genenames/new/tsv/hgnc_complete_set.txt')
+              a.hyper-text.-external(target='_blank', href='https://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt')
                 | HGNC symbol report
-            td 2022/9/16
+            td 2023/09/05
             td 遺伝子シンボルや関連リソースの情報
             td HGNC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/LitVar/')
+              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/research/litvar2/api')
                 | LitVar
             td APIで取得
             td バリアント名が出現する文献情報
             td NCBI
           tr
             td
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pubmed/')
+                | PubMed
+            td 2023/09/01
+            td 文献情報
+            td NCBI
+          tr
+            td
               a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/lu/PubTatorCentral/')
                 | PubTator Central
-            td 2022/9/20
+            td 2023/09/03
             td バリアント名が出現する文献情報
             td NCBI
           tr
@@ -230,7 +243,7 @@ article.common-document
             td DBCLS
       p.notice
         | 注：ClinVarはGRCh37上の位置が決定しているバリアントのみを含む
-        a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/') VCFファイル
+        a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/') VCFファイル
         | からデータを取得しています。
     section.section
       h3.sectiontitle データ加工に利用したツール
@@ -246,7 +259,7 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://samtools.github.io/bcftools/') bcftools
             td._align-center —
-            td Indelの正規化とmultiallelicバリアントのbiallelicバリアントへの分割
+            td multiallelicバリアントのbiallelicバリアントへの分割
             td Genome Research Ltd.
           tr
             td
@@ -259,7 +272,7 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/index.html')
                 | Variant Effect Predictor (VEP)
-            td Ensembl rel. 107
+            td Ensembl rel. 110
             td
               | バリアントに
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html#cache_content')

--- a/app/frontend/views/doc/ja/datasets_grch38.pug
+++ b/app/frontend/views/doc/ja/datasets_grch38.pug
@@ -149,7 +149,7 @@ article.common-document
             td._align-center
               span(style='margin-left:-3px;') 54,302
             td._align-center
-              | Simple検索結果を記入する
+              | 262,200,990
             td 東北メディカル・メガバンク機構
             td v20230626
       p.notice

--- a/app/frontend/views/doc/ja/datasets_grch38.pug
+++ b/app/frontend/views/doc/ja/datasets_grch38.pug
@@ -80,7 +80,7 @@ article.common-document
           | Japanese Genotype-phenotype Archive (JGA)
         |  /
         |
-        a.hyper-text.-external(target='_blank', href='https://www.biobank.amed.go.jp/itc/agd/index.html')
+        a.hyper-text.-external(target='_blank', href='https://gr-sharingdbs.biosciencedbc.jp/agd')
           | AMED Genome group sharing Database (AGD)
         br
         | ∗2：fastq/bam/celファイルやgenotype data一覧など
@@ -106,7 +106,7 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads')
+              a.hyper-text.-external(target='_blank', href='https://gnomad.broadinstitute.org/downloads#v3')
                 | Genome Aggregation Database (gnomAD) genomes
             td._align-left WGS
             td._align-center
@@ -118,7 +118,7 @@ article.common-document
             td._align-center
               | 759,302,267
             td Broad Institute
-            td v3.1.2
+            td v3.1.1
           tr
             td
               a.hyper-text.-external(target='_blank', href='http://www.hgvd.genome.med.kyoto-u.ac.jp/download.html')
@@ -149,11 +149,11 @@ article.common-document
             td._align-center
               span(style='margin-left:-3px;') 54,302
             td._align-center
-              | Simplesearch検索結果を記入する
+              | Simple検索結果を記入する
             td 東北メディカル・メガバンク機構
             td v20230626
       p.notice
-        | 注：#{ GLOBALS.TOMMO_VERSION }KJPNのautosome、ChrX_PAR2、ChrX_PAR3およびmitochondriaを含みます。
+        | 注：#{ GLOBALS.TOMMO_VERSION }KJPNの内訳はSNVs(Autosome, chrX(PAR1+PAR2+XTR)およびchrMT)ならびにINDELs(AutosomeおよびchrX(PAR1+PAR2+XTR))です。
     section.section
       h3.sectiontitle バリアント頻度以外のデータ
       table.table
@@ -166,13 +166,13 @@ article.common-document
         tbody
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
-            td 2023/8/7
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
+            td 2023/09/11
             td バリアントの臨床的意義
             td NCBI
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.dbcls.jp/colil') Colil
+              a.hyper-text.-external(target='_blank', href='https://ftp.dbcls.jp/colil') Colil
             td APIで取得
             td 生命科学分野の文献間の引用関係の情報
             td DBCLS
@@ -185,24 +185,31 @@ article.common-document
             td GRC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/')
+              a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/docs/file-downloads')
                 | GWAS Catalog
             td 2023/09/05
             td ゲノムワイド関連解析(GWAS)情報
             td NHGRI-EBI
           tr
             td
-              a.hyper-text.-external(target='_blank', href='ftp://ftp.ebi.ac.uk/pub/databases/genenames/new/tsv/hgnc_complete_set.txt')
+              a.hyper-text.-external(target='_blank', href='https://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt')
                 | HGNC symbol report
             td 2023/09/05
             td 遺伝子シンボルや関連リソースの情報
             td HGNC
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/LitVar/')
+              a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/research/litvar2/api')
                 | LitVar
             td APIで取得
             td バリアント名が出現する文献情報
+            td NCBI
+          tr
+            td
+              a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pubmed/')
+                | PubMed
+            td 2023/09/01
+            td 文献情報
             td NCBI
           tr
             td
@@ -235,7 +242,7 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://samtools.github.io/bcftools/') bcftools
             td._align-center —
-            td Indelの正規化とmultiallelicバリアントのbiallelicバリアントへの分割
+            td multiallelicバリアントのbiallelicバリアントへの分割
             td Genome Research Ltd.
           tr
             td

--- a/app/frontend/views/doc/ja/datasets_grch38.pug
+++ b/app/frontend/views/doc/ja/datasets_grch38.pug
@@ -139,21 +139,21 @@ article.common-document
               | (2017/08/02)
           tr
             td
-              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-14kjpn-20211208r2-af_snvindelall')
-                | ToMMo #{ GLOBALS.TOMMO_VERSION }KJPN Allele Frequency Panel(#{ GLOBALS.TOMMO_VERSION }KJPN)
+              a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall')
+                | ToMMo #{ GLOBALS.TOMMO_VERSION }KJPN-SNV/INDEL Allele Frequency Panel(#{ GLOBALS.TOMMO_VERSION }KJPN)
             td._align-left WGS
             td._align-center
             td._align-left 日本人
             td._align-center ✔
             td._align-center
             td._align-center
-              span(style='margin-left:-3px;') 約14,000
+              span(style='margin-left:-3px;') 54,302
             td._align-center
-              | 133,757,499
+              | Simplesearch検索結果を記入する
             td 東北メディカル・メガバンク機構
-            td v20211208r2
+            td v20230626
       p.notice
-        | 注：#{ GLOBALS.TOMMO_VERSION }KJPNの内訳は、SNV (Autosome、chrX(PAR1+PAR2+XTR)、chrMT)とINDEL (Autosome、chrX(PAR1+PAR2+XTR))です。
+        | 注：#{ GLOBALS.TOMMO_VERSION }KJPNのautosome、ChrX_PAR2、ChrX_PAR3およびmitochondriaを含みます。
     section.section
       h3.sectiontitle バリアント頻度以外のデータ
       table.table
@@ -167,7 +167,7 @@ article.common-document
           tr
             td
               a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/') ClinVar
-            td 2022/09/01
+            td 2023/8/7
             td バリアントの臨床的意義
             td NCBI
           tr
@@ -187,14 +187,14 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://www.ebi.ac.uk/gwas/')
                 | GWAS Catalog
-            td 2022/09/16
+            td 2023/09/05
             td ゲノムワイド関連解析(GWAS)情報
             td NHGRI-EBI
           tr
             td
               a.hyper-text.-external(target='_blank', href='ftp://ftp.ebi.ac.uk/pub/databases/genenames/new/tsv/hgnc_complete_set.txt')
                 | HGNC symbol report
-            td 2022/09/16
+            td 2023/09/05
             td 遺伝子シンボルや関連リソースの情報
             td HGNC
           tr
@@ -208,7 +208,7 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://ftp.ncbi.nlm.nih.gov/pub/lu/PubTatorCentral/')
                 | PubTator Central
-            td 2022/09/20
+            td 2023/09/03
             td バリアント名が出現する文献情報
             td NCBI
           tr
@@ -218,7 +218,7 @@ article.common-document
             td ゲノムに関する包括的な情報
             td DBCLS
       p.notice
-        | 注：ClinVarはGRCh37上の位置が決定しているバリアントのみを含む
+        | 注：ClinVarはGRCh38上の位置が決定しているバリアントのみを含む
         a.hyper-text.-external(target='_blank', href='ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/') VCFファイル
         | からデータを取得しています。
     section.section
@@ -248,7 +248,7 @@ article.common-document
             td
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/index.html')
                 | Variant Effect Predictor (VEP)
-            td Ensembl rel. 107
+            td Ensembl rel. 110
             td
               | バリアントに
               a.hyper-text.-external(target='_blank', href='https://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html#cache_content')

--- a/app/frontend/views/doc/ja/downloads.pug
+++ b/app/frontend/views/doc/ja/downloads.pug
@@ -16,31 +16,78 @@ block content
         h2.title Downloads
       .contents
         section.section
-          p.body TogoVarデータは以下のリンクからダウンロード可能です。
+          h3.sectiontitle
+            | TogoVarの全バリアントデータ
           ul
             li
-              a(href='/downloads/gem_j_wga/')
-                | GEM Japan Whole Genome Aggregation (GEM-J WGA) パネルの頻度情報 (VCFフォーマット)
-              p
-                | 日本各地から収集した7,609人分の全ゲノム配列情報(Whole Genome Sequence: WGS) をバリアント検知して得られた
-                | 日本人一般集団の大規模バリアント頻度データセットです。全ゲノム配列情報も制限公開データとして利用可能です。
-                | 国立研究開発法人日本医療研究開発機構(AMED)が推進するGEnome Medical alliance Japan（GEM Japan, ジェムジャパン）
-                | プロジェクトの一環として実施されました。
-                a(href='/doc/ja/datasets/gem_j_wga') [詳細]
-                a(href='/downloads/gem_j_wga') [ダウンロード]
+              | アレル頻度
+              ul
+                li
+                  | GRCh38：
+                  a(href='/downloads/release/current/grch38/frequency/vcf') VCF形式
+                  |
+                  | |
+                  |
+                  a(href='/downloads/release/current/grch38/frequency/tsv') タブ区切りテキスト
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch38/frequency/tsv/README.txt') README
+                  | )
+                li
+                  | GRCh37：
+                  a(href='/downloads/release/current/grch37/frequency/vcf') VCF形式
+                  |
+                  | |
+                  |
+                  a(href='/downloads/release/current/grch37/frequency/tsv') タブ区切りテキスト
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch37/frequency/tsv/README.txt') README
+                  | )
             li
-              a(href='/downloads/release/current')
-                | GEM-J WGA以外のバリアントの頻度情報 (JGA-NGS, JGA-SNP, ExAC, #{ GLOBALS.TOMMO_VERSION }KJPN, HGVD)(タブ区切りフォーマット)
-              p
-                a(href='/doc/ja/datasets/jga_ngs') JGA-NGS
-                | と
-                a(href='/doc/ja/datasets/jga_snp') JGA-SNP
-                | は、
-                a.hyper-text.-external(target='_blank', href='https://humandbs.biosciencedbc.jp/') NBDCヒトデータベース
-                |  /
-                |
-                a.hyper-text.-external(target='_blank', href='https://www.ddbj.nig.ac.jp/jga/index-e.html')
-                  | Japanese Genotype-phenotype Archive (JGA)
-                | に登録されている個人レベルのゲノムデータを集約した頻度データです。
-                a(href='/doc/ja/datasets') [詳細]
-                a(href='/downloads/release/current') [ダウンロード]
+              | アノテーション
+              ul
+                li
+                  | GRCh38：
+                  a(href='/downloads/release/current/grch38/annotation') タブ区切りテキスト
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch38/annotation/README.txt') README
+                  | )
+                li
+                  | GRCh37：
+                  a(href='/downloads/release/current/grch37/annotation') タブ区切りテキスト
+                  |
+                  | (
+                  a(href='/downloads/release/current/grch37/annotation/README.txt') README
+                  | )
+            br
+            p
+            | 最終更新日：2023/11/7
+            br
+            | アレル頻度は、
+            |
+            a(href='/doc/ja/datasets/') データセット
+            | ごとに集計されました。
+        section.section
+          h3.sectiontitle
+            | 寄託者から提供されたオリジナルファイル（一部のデータセット）
+          ul
+            li
+              | GEM Japan Whole Genome Aggregation (GEM-J WGA) パネル
+              ul
+                li
+                  | アレル頻度
+                ul
+                  li
+                    | GRCh38 (liftover from GRCh37)：
+                    a(href='/downloads/gem_j_wga/grch38') VCF形式
+                  li
+                    | GRCh37：
+                    a(href='/downloads/gem_j_wga/grch37') VCF形式
+            p
+            | 最終更新日：2021/11/29
+            br
+            | データセットの詳細は、
+            a(href='/doc/ja/datasets/gem_j_wga') GEM-J WGAのページ
+            | をご覧ください。

--- a/app/frontend/views/doc/ja/history.pug
+++ b/app/frontend/views/doc/ja/history.pug
@@ -16,18 +16,18 @@ block content
         h2.title 更新履歴
       .contents
         section.section
-          h3.sectiontitle 2023/9/26
+          h3.sectiontitle 2023/11/7
           ul.unordered-list
             li
               strong Datasets:
               |
-              | ToMMo 14KJPNを
+              | ToMMo 14KJPNをToMMo 54KJPN (
               a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall') ToMMo 54KJPN Allele Frequency Panel
-              | に更新しました。
+              | )に更新しました。
             li
               strong Advanced search:
               |
-              | TogoVarおよびdbSNPのバリアントIDならびにHGNC遺伝子シンボルのリストを入力してTogoVarを検索できるようになりました。
+              | バリアントID（例：tgv47264307(TogoVar)、rs671(dbSNP)）で検索可能になりました。
             li
               strong Downloads:
               |
@@ -105,9 +105,9 @@ block content
               strong Gene page/Disease page:
               | 1遺伝子（例：
               a.hyper-text.-internal(href='/gene/8618') PAX4
-              |) および1疾患(例：
+              |）および1疾患（例：
               a.hyper-text.-internal(href='/disease/C0023467') Acute myeloid leukemia 
-              |)に関連するバリアント情報のページを公開しました。
+              |）に関連するバリアント情報のページを公開しました。
             li
               strong Variant page/Gene page/Disease page:
               | 
@@ -157,7 +157,7 @@ block content
           ul.unordered-list
             li
               strong Keyword search:
-              |  HGNC Gene Symbolの別名(例：PD-1、p53)で検索できるようになりました。
+              |  HGNC Gene Symbolの別名（例：PD-1、p53）で検索できるようになりました。
             li
               strong Filters:
               |  Alternative allele frequencyを検索条件にする場合に、検索対象としてユーザーが選択した「全てのDataset」または「いずれかのDataset」のどちらかを指定できるようになりました。

--- a/app/frontend/views/doc/ja/history.pug
+++ b/app/frontend/views/doc/ja/history.pug
@@ -16,6 +16,26 @@ block content
         h2.title 更新履歴
       .contents
         section.section
+          h3.sectiontitle 2023/9/26
+          ul.unordered-list
+            li
+              strong Datasets:
+              |
+              | ToMMo 14KJPNを
+              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall') ToMMo 54KJPN Allele Frequency Panel
+              | に更新しました。
+            li
+              strong Advanced search:
+              |
+              | TogoVarおよびdbSNPのバリアントIDならびにHGNC遺伝子シンボルのリストを入力してTogoVarを検索できるようになりました。
+            li
+              strong Downloads:
+              |
+              | 全バリアントのアレル頻度がこれまでのタブ区切り形式に加え、
+              |
+              a.hyper-text.-external(href='https://samtools.github.io/hts-specs/VCFv4.4.pdf')
+                | VCF形式
+              | でダウンロードできるようになりました。
           h3.sectiontitle 2023/7/14
           ul.unordered-list
             li

--- a/app/frontend/views/includes/_globals.pug
+++ b/app/frontend/views/includes/_globals.pug
@@ -3,6 +3,6 @@ case TOGOVAR_FRONTEND_REFERENCE
   when 'GRCh37'
     - GLOBALS.TOMMO_VERSION = "8.3";
   when 'GRCh38'
-    - GLOBALS.TOMMO_VERSION = "14";
+    - GLOBALS.TOMMO_VERSION = "54";
   default
     // none


### PR DESCRIPTION
ToMMo54KJPNおよびClinVarなどの参照データを更新するために必要なドキュメントの更新をしました。レビューとマージをお願いします。

1. GRCh38, GRCh37の両方を更新する予定です。公開日は11/7を記入しています。
2. GRCh38のGLOBALS.TOMMO_VERSIONを54に更新するcommitを含んでいます。
```
app/frontend/views/includes/_globals.pug
  when 'GRCh37'
    - GLOBALS.TOMMO_VERSION = "8.3";
  when 'GRCh38'
    - GLOBALS.TOMMO_VERSION = "54";
  default
    // none
```
3.  downloadsファイルのVCFファイルを追加するためにdownloadsディレクトリ構造を変更し、downloadsページは変更後のパスにリンクしています。
- 頻度ファイル
  -  downloads/release/20231027/grch{38,37}/frequency/vcf/chr*.vcf.gzと*chr*vcf.gz.tbi  (VCF)
  - downloads/release/20231027/grch{38,37}/frequency/vcf/chr*.tsv.gz   (TSV)
- アノテーションファイル：downloads/release/20231027/grch{38,37}/annotation/*.tsv.gz