### PR TITLE
Hotfix 54kjpn

### DIFF
--- a/app/frontend/assets/GRCh38/advanced_search_conditions.json
+++ b/app/frontend/assets/GRCh38/advanced_search_conditions.json
@@ -25,8 +25,8 @@
         {
           "id": 4,
           "value": "tommo",
-          "label": "ToMMo 14KJPN",
-          "description": "ToMMo 14KJPN Allele Frequency Panel"
+          "label": "ToMMo 54KJPN",
+          "description": "ToMMo 54KJPN-SNV/INDEL Allele Frequency Panel (v20230626)"
         },
         {
           "id": 5,
@@ -407,13 +407,13 @@
       "label": "Gene symbol",
       "type": "text"
     },
-    "id": {
-      "label": "Variant ID",
-      "type": "text"
-    },
     "location": {
       "label": "Location",
       "type": "peculiar"
+    },
+    "id": {
+      "label": "Variant ID",
+      "type": "text"
     },
     "type": {
       "label": "Variant type",

--- a/app/frontend/assets/GRCh38/search_conditions.json
+++ b/app/frontend/assets/GRCh38/search_conditions.json
@@ -33,7 +33,7 @@
       },
       {
         "id": "tommo",
-        "label": "ToMMo 14KJPN",
+        "label": "ToMMo 54KJPN",
         "type": "boolean",
         "default": "1",
         "has_freq": true

--- a/app/frontend/views/doc/en/datasets_grch38.pug
+++ b/app/frontend/views/doc/en/datasets_grch38.pug
@@ -114,7 +114,7 @@ article.common-document
             td._align-center
               | 759,302,267
             td Broad Institute
-            td v3.1.1
+            td v3.1.2
           tr
             td
               a.hyper-text.-external(target='_blank', href='http://www.hgvd.genome.med.kyoto-u.ac.jp/download.html')

--- a/app/frontend/views/doc/ja/datasets_grch38.pug
+++ b/app/frontend/views/doc/ja/datasets_grch38.pug
@@ -118,7 +118,7 @@ article.common-document
             td._align-center
               | 759,302,267
             td Broad Institute
-            td v3.1.1
+            td v3.1.2
           tr
             td
               a.hyper-text.-external(target='_blank', href='http://www.hgvd.genome.med.kyoto-u.ac.jp/download.html')


### PR DESCRIPTION
以下の微修正をしました。
1.  gnomADのバージョンを3.1.2に変更
2.  Statisitcs/FilterのDatasetのToMMo 14KJPNをToMMo 54KJPNに変更
3. Advanced searchのメニューのVariant IDをLocationの後に移動（alphabetical orderのため）