### PR TITLE
add protain browser to gene page

### DIFF
--- a/app/frontend/config/stanza.yaml
+++ b/app/frontend/config/stanza.yaml
@@ -250,6 +250,14 @@ gene:
         jbrowse: $TOGOVAR_STANZA_JBROWSE
         margin: 200
 
+    - id: gene-protein-browser
+      dom: '#gene-protein-browser'
+      options:
+        hgnc_id: ${hgnc_id}
+        togovar_target: stg-grch38
+        jpost_endpoint: https://db-dev.jpostdb.org/proxy/sparql
+        glycosmos_endpoint: https://ts.glycosmos.org/sparql
+
     - id: gene-protein-structure
       dom: '#gene-protein-structure'
       options:

--- a/app/frontend/views/gene/index.pug
+++ b/app/frontend/views/gene/index.pug
@@ -51,6 +51,13 @@ block content
           | Genomic context
       #gene-genomic-context.stanza
 
+    section.stanza-view#protein-browser
+      .titlelink-wrapper
+        a.titlelink(href="#protein-browser")
+        h3.title
+          | Protein browser
+      #gene-protein-browser.stanza
+
     section.stanza-view#protein-structure
       .titlelink-wrapper
         a.titlelink(href="#protein-structure")


### PR DESCRIPTION
TODO:
- Replace stg-grch38 in togovar_target with TOGOVAR_FRONTEND_API_URL (e.g., https://stg-grch38.togovar.org) in the .env file.
- Update https://stg-grch38.togovar.org/sparqlist/gene_protein_browser to refer to TOGOVAR_FRONTEND_API_URL.
- Parameterize the values of jpost_endpoint and glycosmos_endpoint in stanza.yml.
```
    - id: gene-protein-browser
      dom: '#gene-protein-browser'
      options:
        hgnc_id: ${hgnc_id}
        togovar_target: stg-grch38
        jpost_endpoint: https://db-dev.jpostdb.org/proxy/sparql
        glycosmos_endpoint: https://ts.glycosmos.org/sparql
```