### PR TITLE
add double quotes to suggest

### DIFF
--- a/app/frontend/src/components/Common/SearchField/SearchFieldWithSuggestions.js
+++ b/app/frontend/src/components/Common/SearchField/SearchFieldWithSuggestions.js
@@ -248,11 +248,14 @@ class SearchFieldtWithSuggestions extends LitElement {
    * @param {Object} suggestion - Symple{term, alias_of}, Gene{slias_of, highlight, id, name, symbol}
    * @private */
   _select = (suggestion) => {
+    const escapeString = (str) =>
+      str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
     this.value = `"${
-      suggestion[this._searchFieldOptions.valueMappings.valueKey]
+      escapeString(suggestion[this._searchFieldOptions.valueMappings.valueKey])
     }"`;
     this.label = `"${
-      suggestion[this._searchFieldOptions.valueMappings.labelKey]
+      escapeString(suggestion[this._searchFieldOptions.valueMappings.labelKey])
     }"`;
 
     this.dispatchEvent(

--- a/app/frontend/src/components/Common/SearchField/SearchFieldWithSuggestions.js
+++ b/app/frontend/src/components/Common/SearchField/SearchFieldWithSuggestions.js
@@ -248,14 +248,18 @@ class SearchFieldtWithSuggestions extends LitElement {
    * @param {Object} suggestion - Symple{term, alias_of}, Gene{slias_of, highlight, id, name, symbol}
    * @private */
   _select = (suggestion) => {
-    this.value = suggestion[this._searchFieldOptions.valueMappings.valueKey];
-    this.label = suggestion[this._searchFieldOptions.valueMappings.labelKey];
+    this.value = `"${
+      suggestion[this._searchFieldOptions.valueMappings.valueKey]
+    }"`;
+    this.label = `"${
+      suggestion[this._searchFieldOptions.valueMappings.labelKey]
+    }"`;
 
     this.dispatchEvent(
       new CustomEvent('new-suggestion-selected', {
         detail: {
-          id: suggestion[this._searchFieldOptions.valueMappings.valueKey],
-          label: suggestion[this._searchFieldOptions.valueMappings.labelKey],
+          id: this.value,
+          label: this.label,
         },
         bubbles: true,
         composed: true,

--- a/app/frontend/src/components/Common/SearchField/SearchFieldWithSuggestions.js
+++ b/app/frontend/src/components/Common/SearchField/SearchFieldWithSuggestions.js
@@ -27,7 +27,7 @@ import { storeManager } from '../../../store/StoreManager';
  * {@link ConditionValueEditorGene},
  * {@link ConditionValueEditorDisease} */
 @customElement('search-field-with-suggestions')
-class SearchFieldtWithSuggestions extends LitElement {
+class SearchFieldWithSuggestions extends LitElement {
   static styles = [Styles];
 
   /**
@@ -160,11 +160,9 @@ class SearchFieldtWithSuggestions extends LitElement {
       storeManager.setData('showSuggest', false);
     }
 
+    const arrowKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
     if (
-      (e.key === 'ArrowUp' ||
-        e.key === 'ArrowDown' ||
-        e.key === 'ArrowLeft' ||
-        e.key === 'ArrowRight') &&
+      arrowKeys.includes(e.key) &&
       this.showSuggestions &&
       this.currentSuggestionIndex !== -1
     ) {
@@ -249,21 +247,20 @@ class SearchFieldtWithSuggestions extends LitElement {
    * @private */
   _select = (suggestion) => {
     const escapeString = (str) =>
-      str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      String(str || '')
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"');
 
-    this.value = `"${
-      escapeString(suggestion[this._searchFieldOptions.valueMappings.valueKey])
-    }"`;
-    this.label = `"${
-      escapeString(suggestion[this._searchFieldOptions.valueMappings.labelKey])
-    }"`;
+    const valueKey =
+      suggestion[this._searchFieldOptions.valueMappings.valueKey] || '';
+    const labelKey =
+      suggestion[this._searchFieldOptions.valueMappings.labelKey] || '';
+    this.value = `"${escapeString(valueKey)}"`;
+    this.label = `"${escapeString(labelKey)}"`;
 
     this.dispatchEvent(
       new CustomEvent('new-suggestion-selected', {
-        detail: {
-          id: this.value,
-          label: this.label,
-        },
+        detail: { id: this.value, label: this.label },
         bubbles: true,
         composed: true,
       })
@@ -290,12 +287,12 @@ class SearchFieldtWithSuggestions extends LitElement {
     this._select(e.detail);
   };
 
-  /** Put the characters input in this.term, (Only SimpleSearch)create imput-term event, hide suggestions if the length is less than 3, and empty suggestData
+  /** Put the characters input in this.term, (Only SimpleSearch)create input-term event, hide suggestions if the length is less than 3, and empty suggestData
    * @private */
   _handleInput(e) {
     this.term = e.data;
     this.dispatchEvent(
-      new CustomEvent('imput-term', {
+      new CustomEvent('input-term', {
         detail: e.data,
         bubbles: true,
         composed: true,
@@ -384,4 +381,4 @@ class SearchFieldtWithSuggestions extends LitElement {
   }
 }
 
-export default SearchFieldtWithSuggestions;
+export default SearchFieldWithSuggestions;

--- a/app/frontend/src/components/Common/SearchField/SimpleSearchView.js
+++ b/app/frontend/src/components/Common/SearchField/SimpleSearchView.js
@@ -146,7 +146,7 @@ class SimpleSearchView extends LitElement {
 
   /** Put input value in this._term
    * @private
-   * @param {CustomEvent} e - imput-term (SearchFieldWithSuggestions) */
+   * @param {CustomEvent} e - input-term (SearchFieldWithSuggestions) */
   _inputTerm(e) {
     this._term = e.detail;
     // 入力されたテキストを検索条件に反映する（ただし検索は実行しない）
@@ -201,7 +201,7 @@ class SimpleSearchView extends LitElement {
           .hideSuggestions=${this._hideSuggestions}
           @new-suggestion-selected=${this._handleSuggestionEnter}
           @search-term-enter=${this._handleTermEnter}
-          @imput-term=${this._inputTerm}
+          @input-term=${this._inputTerm}
           @input=${() => (this._hideSuggestions = false)}
           @input-reset=${this._handleInputReset}
         ></search-field-with-suggestions>


### PR DESCRIPTION
[issue286](https://github.com/togovar/meeting/issues/286)に関する修正を行いました。
disease検索のキーフレーズをダブルクォートで囲みました。

---
【Copilot】
This pull request updates the `SearchFieldWithSuggestions` component to improve how suggestion values and labels are handled and displayed. Specifically, it ensures that both the `value` and `label` are consistently wrapped in double quotes.

### Key changes to `SearchFieldWithSuggestions`:

* Updated the `_select` method to wrap the `value` and `label` properties in double quotes when assigning them from the selected suggestion. This ensures a consistent format for these fields.
* Modified the `new-suggestion-selected` event to use the newly quoted `value` and `label` properties for the `id` and `label` in the event details.