### PR TITLE
Fix/seo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,12 @@
       "rules": {
         "@typescript-eslint/no-var-requires": "off"
       }
+    },
+    {
+      "files": ["app/frontend/server/**/*.js"],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
     }
   ],
 

--- a/app/frontend/config/siteOrigin.js
+++ b/app/frontend/config/siteOrigin.js
@@ -1,0 +1,28 @@
+const DEFAULT_REFERENCE = 'GRCh38';
+
+const SITE_ORIGINS = {
+  GRCh37: 'https://grch37.togovar.org',
+  GRCh38: 'https://grch38.togovar.org',
+};
+
+function normalizeOrigin(origin) {
+  return origin.replace(/\/+$/, '');
+}
+
+function getDefaultSiteOrigin(reference) {
+  return SITE_ORIGINS[reference] || SITE_ORIGINS[DEFAULT_REFERENCE];
+}
+
+function getSiteOrigin(env = process.env) {
+  if (env.TOGOVAR_SITE_ORIGIN) {
+    return normalizeOrigin(env.TOGOVAR_SITE_ORIGIN);
+  }
+
+  return getDefaultSiteOrigin(env.TOGOVAR_REFERENCE || DEFAULT_REFERENCE);
+}
+
+module.exports = {
+  DEFAULT_REFERENCE,
+  SITE_ORIGINS,
+  getSiteOrigin,
+};

--- a/app/frontend/config/webpack.config.common.js
+++ b/app/frontend/config/webpack.config.common.js
@@ -4,21 +4,10 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { getSiteOrigin } = require('./siteOrigin');
 
 const env = require('dotenv').config().parsed || {};
 Object.assign(process.env, env);
-
-// SEO用の静的ファイルを作るときに使う、本番公開URLの対応表。
-// .env の TOGOVAR_REFERENCE に合わせて、GRCh37/GRCh38 のURLを切り替える。
-const SITE_ORIGINS = {
-  GRCh37: 'https://grch37.togovar.org',
-  GRCh38: 'https://grch38.togovar.org',
-};
-
-// TOGOVAR_REFERENCE が未設定または想定外の場合は、現在の標準であるGRCh38を使う。
-function getSiteOrigin() {
-  return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
-}
 
 // 検索エンジン向けの robots.txt を生成する。
 // ここではクロールを許可し、同時に sitemap.xml の場所を知らせる。
@@ -240,6 +229,7 @@ const config = {
         process.env.TOGOVAR_FRONTEND_API_URL
       ),
       TOGOVAR_FRONTEND_REFERENCE: JSON.stringify(process.env.TOGOVAR_REFERENCE),
+      TOGOVAR_FRONTEND_SITE_ORIGIN: JSON.stringify(getSiteOrigin()),
       TOGOVAR_FRONTEND_STANZA_URL: JSON.stringify(
         process.env.TOGOVAR_FRONTEND_STANZA_URL
       ),

--- a/app/frontend/config/webpack.config.common.js
+++ b/app/frontend/config/webpack.config.common.js
@@ -37,8 +37,8 @@ function createRobotsTxt(siteOrigin) {
 function createSitemapXml(siteOrigin, pages) {
   const urls = [
     `${siteOrigin}/`,
-    ...pages.map(page => `${siteOrigin}/doc/${page}`),
-    ...pages.map(page => `${siteOrigin}/doc/ja/${page}`),
+    ...pages.map(page => `${siteOrigin}/doc/${page}/`),
+    ...pages.map(page => `${siteOrigin}/doc/ja/${page}/`),
   ];
 
   return [
@@ -328,7 +328,7 @@ pages.forEach(function (name) {
       filename: `doc/ja/${name}/index.html`,
       // 各ドキュメントページ自身のURLを canonical としてテンプレートへ渡す。
       templateParameters: {
-        canonicalUrl: `${getSiteOrigin()}/doc/ja/${name}`,
+        canonicalUrl: `${getSiteOrigin()}/doc/ja/${name}/`,
       },
       inject: false,
     }),
@@ -337,7 +337,7 @@ pages.forEach(function (name) {
       filename: `doc/${name}/index.html`,
       // 英語ページは /doc/{name} を正規URLとして扱う。
       templateParameters: {
-        canonicalUrl: `${getSiteOrigin()}/doc/${name}`,
+        canonicalUrl: `${getSiteOrigin()}/doc/${name}/`,
       },
       inject: false,
     })

--- a/app/frontend/config/webpack.config.common.js
+++ b/app/frontend/config/webpack.config.common.js
@@ -317,21 +317,35 @@ const pages = (function (assembly) {
   }
 })(process.env.TOGOVAR_REFERENCE);
 
+// pages に定義したドキュメントページを、英語版・日本語版それぞれHTMLとして出力する。
+// 例: name が "datasets" の場合
+//   app/frontend/views/doc/en/datasets.pug -> dist/doc/datasets/index.html
+//   app/frontend/views/doc/ja/datasets.pug -> dist/doc/ja/datasets/index.html
 pages.forEach(function (name) {
   config.plugins.push(
     new HtmlWebpackPlugin({
       template: `app/frontend/views/doc/ja/${name}.pug`,
       filename: `doc/ja/${name}/index.html`,
+      // 各ドキュメントページ自身のURLを canonical としてテンプレートへ渡す。
+      templateParameters: {
+        canonicalUrl: `${getSiteOrigin()}/doc/ja/${name}`,
+      },
       inject: false,
     }),
     new HtmlWebpackPlugin({
       template: `app/frontend/views/doc/en/${name}.pug`,
       filename: `doc/${name}/index.html`,
+      // 英語ページは /doc/{name} を正規URLとして扱う。
+      templateParameters: {
+        canonicalUrl: `${getSiteOrigin()}/doc/${name}`,
+      },
       inject: false,
     })
   );
 });
 
+// robots.txt と sitemap.xml を dist 直下に追加する。
+// sitemap.xml には、上で生成したドキュメントページのURL一覧を含める。
 config.plugins.push(new StaticSeoFilesPlugin(pages));
 
 module.exports = config;

--- a/app/frontend/config/webpack.config.common.js
+++ b/app/frontend/config/webpack.config.common.js
@@ -8,6 +8,83 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const env = require('dotenv').config().parsed || {};
 Object.assign(process.env, env);
 
+// SEO用の静的ファイルを作るときに使う、本番公開URLの対応表。
+// .env の TOGOVAR_REFERENCE に合わせて、GRCh37/GRCh38 のURLを切り替える。
+const SITE_ORIGINS = {
+  GRCh37: 'https://grch37.togovar.org',
+  GRCh38: 'https://grch38.togovar.org',
+};
+
+// TOGOVAR_REFERENCE が未設定または想定外の場合は、現在の標準であるGRCh38を使う。
+function getSiteOrigin() {
+  return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
+}
+
+// 検索エンジン向けの robots.txt を生成する。
+// ここではクロールを許可し、同時に sitemap.xml の場所を知らせる。
+function createRobotsTxt(siteOrigin) {
+  return [
+    'User-agent: *',
+    'Allow: /',
+    '',
+    `Sitemap: ${siteOrigin}/sitemap.xml`,
+    '',
+  ].join('\n');
+}
+
+// webpackで生成している静的ページ一覧から sitemap.xml を生成する。
+// トップページ、英語ドキュメント、日本語ドキュメントを検索エンジンへ伝える。
+function createSitemapXml(siteOrigin, pages) {
+  const urls = [
+    `${siteOrigin}/`,
+    ...pages.map(page => `${siteOrigin}/doc/${page}`),
+    ...pages.map(page => `${siteOrigin}/doc/ja/${page}`),
+  ];
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls.map(url => `  <url><loc>${url}</loc></url>`),
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+// webpackのビルド結果へ robots.txt と sitemap.xml を追加するための独自プラグイン。
+// 実ファイルを手で管理せず、ビルド対象ページとTOGOVAR_REFERENCEに合わせて自動生成する。
+class StaticSeoFilesPlugin {
+  constructor(pages) {
+    this.pages = pages;
+  }
+
+  apply(compiler) {
+    // webpackのコンパイルごとに、アセット追加のタイミングでSEO用ファイルを差し込む。
+    compiler.hooks.thisCompilation.tap('StaticSeoFilesPlugin', compilation => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: 'StaticSeoFilesPlugin',
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        () => {
+          const { RawSource } = compiler.webpack.sources;
+          const siteOrigin = getSiteOrigin();
+
+          // dist/robots.txt として出力される。
+          compilation.emitAsset(
+            'robots.txt',
+            new RawSource(createRobotsTxt(siteOrigin))
+          );
+          // dist/sitemap.xml として出力される。
+          compilation.emitAsset(
+            'sitemap.xml',
+            new RawSource(createSitemapXml(siteOrigin, this.pages))
+          );
+        }
+      );
+    });
+  }
+}
+
 const config = {
   entry: {
     main: './app/frontend/packs/index.ts',
@@ -219,6 +296,24 @@ const pages = (function (assembly) {
         'policy',
         'terms',
       ];
+    default:
+      // TOGOVAR_REFERENCE が未設定または想定外の場合は、現在の標準であるGRCh38のページを生成する。
+      return [
+        'about',
+        'contact',
+        'datasets',
+        'datasets/analysis',
+        'datasets/gem_j_wga',
+        'datasets/jga_wes',
+        'datasets/jga_wgs',
+        'datasets/jga_snp',
+        'datasets/ncbn',
+        'downloads',
+        'help',
+        'history',
+        'policy',
+        'terms',
+      ];
   }
 })(process.env.TOGOVAR_REFERENCE);
 
@@ -236,5 +331,7 @@ pages.forEach(function (name) {
     })
   );
 });
+
+config.plugins.push(new StaticSeoFilesPlugin(pages));
 
 module.exports = config;

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -45,9 +45,11 @@ function getCanonicalUrl(req) {
 
 // 詳細ページ用HTML内のプレースホルダーを、アクセスされたURL自身のcanonicalへ置き換える。
 function withCanonicalUrl(html, req) {
+  const canonicalUrl = escapeHtmlAttribute(getCanonicalUrl(req));
+
   return html.replace(
     /__TOGOVAR_CANONICAL_URL__/g,
-    escapeHtmlAttribute(getCanonicalUrl(req))
+    () => canonicalUrl
   );
 }
 

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -51,6 +51,19 @@ function withCanonicalUrl(html, req) {
   );
 }
 
+function sendReportHtml(outputFileSystem, outputPath, req, res) {
+  outputFileSystem.readFile(
+    path.resolve(outputPath, req.params.report, 'index.html'),
+    (err, file) => {
+      if (err) {
+        res.sendStatus(404);
+      } else {
+        res.send(withCanonicalUrl(file.toString(), req));
+      }
+    }
+  );
+}
+
 module.exports = function addDevMiddlewares(app, webpackConfig) {
   // 開発中はwebpackのビルド結果をディスクではなくメモリ上に作る。
   const compiler = webpack(webpackConfig);
@@ -75,26 +88,22 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
   };
   app.use('/stanza', createProxyMiddleware(proxyOptions));
 
-  // dist配下の静的ファイルを配信する。
-  app.use(publicPath, express.static(outputPath));
-
   // webpack-dev-middleware はビルド結果をメモリ上に保持するため、
   // ディスク上のdistではなく、middlewareが持つファイルシステムからHTMLを読む。
   const outputFileSystem = middleware.context.outputFileSystem;
 
-  // /variant/:id, /gene/:id, /disease/:id は同じHTMLを使い、canonicalだけURLごとに差し替える。
-  app.get('/:report(variant|gene|disease)/:id', (req, res) => {
-    outputFileSystem.readFile(
-      path.resolve(compiler.outputPath, req.params.report, 'index.html'),
-      (err, file) => {
-        if (err) {
-          res.sendStatus(404);
-        } else {
-          res.send(withCanonicalUrl(file.toString(), req));
-        }
-      }
-    );
+  // /variant, /gene, /disease も同じHTMLを使い、canonicalだけURLごとに差し替える。
+  app.get('/:report(variant|gene|disease)/?', (req, res) => {
+    sendReportHtml(outputFileSystem, compiler.outputPath, req, res);
   });
+
+  // /variant/:id, /gene/:id, /disease/:id も同じHTMLを使い、canonicalだけURLごとに差し替える。
+  app.get('/:report(variant|gene|disease)/:id', (req, res) => {
+    sendReportHtml(outputFileSystem, compiler.outputPath, req, res);
+  });
+
+  // dist配下の静的ファイルを配信する。
+  app.use(publicPath, express.static(outputPath));
 
   app.get('/', (req, res) => {
     outputFileSystem.readFile(

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -79,7 +79,7 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
       return res.redirect(302, getTrailingSlashUrl(req));
     }
 
-    sendReportHtml(outputFileSystem, compiler.outputPath, req, res);
+    sendReportHtml(outputFileSystem, outputPath, req, res);
   });
 
   // /variant/:id, /gene/:id, /disease/:id も同じHTMLを使い、canonicalだけURLごとに差し替える。
@@ -88,13 +88,13 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
       return res.redirect(302, getNoTrailingSlashUrl(req));
     }
 
-    sendReportHtml(outputFileSystem, compiler.outputPath, req, res);
+    sendReportHtml(outputFileSystem, outputPath, req, res);
   });
 
   // トップページも、開発中はメモリ上の最新HTMLを返す。
   app.get('/', (req, res) => {
     outputFileSystem.readFile(
-      path.resolve(compiler.outputPath, 'index.html'),
+      path.resolve(outputPath, 'index.html'),
       (err, file) => {
         if (err) {
           res.sendStatus(404);

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -104,9 +104,7 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
     sendReportHtml(outputFileSystem, compiler.outputPath, req, res);
   });
 
-  // dist配下の静的ファイルを配信する。
-  app.use(publicPath, express.static(outputPath));
-
+  // トップページも、開発中はメモリ上の最新HTMLを返す。
   app.get('/', (req, res) => {
     outputFileSystem.readFile(
       path.resolve(compiler.outputPath, 'index.html'),
@@ -119,4 +117,7 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
       }
     );
   });
+
+  // dist配下の静的ファイルを配信する。
+  app.use(publicPath, express.static(outputPath));
 };

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -70,6 +70,11 @@ function getTrailingSlashUrl(req) {
   return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
 }
 
+function getNoTrailingSlashUrl(req) {
+  const queryString = req.originalUrl.slice(req.path.length);
+  return `${req.path.replace(/\/+$/, '')}${queryString}`;
+}
+
 module.exports = function addDevMiddlewares(app, webpackConfig) {
   // 開発中はwebpackのビルド結果をディスクではなくメモリ上に作る。
   const compiler = webpack(webpackConfig);
@@ -109,6 +114,10 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
 
   // /variant/:id, /gene/:id, /disease/:id も同じHTMLを使い、canonicalだけURLごとに差し替える。
   app.get('/:report(variant|gene|disease)/:id', (req, res) => {
+    if (req.path.endsWith('/')) {
+      return res.redirect(302, getNoTrailingSlashUrl(req));
+    }
+
     sendReportHtml(outputFileSystem, compiler.outputPath, req, res);
   });
 

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -12,20 +12,32 @@ function createWebpackMiddleware(compiler, publicPath) {
   });
 }
 
+function getCanonicalUrl(req) {
+  const protocol = req.get('x-forwarded-proto') || req.protocol;
+  return `${protocol}://${req.get('host')}${req.originalUrl.split('?')[0]}`;
+}
+
+// 詳細ページ用HTML内のプレースホルダーを、アクセスされたURL自身のcanonicalへ置き換える。
+function withCanonicalUrl(html, req) {
+  return html.replace(/__TOGOVAR_CANONICAL_URL__/g, getCanonicalUrl(req));
+}
+
 module.exports = function addDevMiddlewares(app, webpackConfig) {
+  // 開発中はwebpackのビルド結果をディスクではなくメモリ上に作る。
   const compiler = webpack(webpackConfig);
   const middleware = createWebpackMiddleware(
     compiler,
-    webpackConfig.output.publicPath,
+    webpackConfig.output.publicPath
   );
 
   const publicPath = webpackConfig.output.publicPath || '/';
-  const outputPath = webpackConfig.output.path || path.resolve(process.cwd(), 'dist');
+  const outputPath =
+    webpackConfig.output.path || path.resolve(process.cwd(), 'dist');
 
   app.use(middleware);
   app.use(webpackHotMiddleware(compiler));
 
-  // proxy
+  // 開発中の /stanza/* リクエストを、ローカルのStanza開発サーバーへ転送する。
   const proxyOptions = {
     target: 'http://localhost:8080',
     pathRewrite: {
@@ -34,30 +46,37 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
   };
   app.use('/stanza', createProxyMiddleware(proxyOptions));
 
-  // serve static assets under /dist
+  // dist配下の静的ファイルを配信する。
   app.use(publicPath, express.static(outputPath));
 
-  // Since webpackDevMiddleware uses memory-fs internally to store build
-  // artifacts, we use it instead
-  const fs = middleware.context.outputFileSystem;
+  // webpack-dev-middleware はビルド結果をメモリ上に保持するため、
+  // ディスク上のdistではなく、middlewareが持つファイルシステムからHTMLを読む。
+  const outputFileSystem = middleware.context.outputFileSystem;
 
+  // /variant/:id, /gene/:id, /disease/:id は同じHTMLを使い、canonicalだけURLごとに差し替える。
   app.get('/:report(variant|gene|disease)/:id', (req, res) => {
-    fs.readFile(path.resolve(compiler.outputPath, req.params.report, 'index.html'), (err, file) => {
-      if (err) {
-        res.sendStatus(404);
-      } else {
-        res.send(file.toString());
+    outputFileSystem.readFile(
+      path.resolve(compiler.outputPath, req.params.report, 'index.html'),
+      (err, file) => {
+        if (err) {
+          res.sendStatus(404);
+        } else {
+          res.send(withCanonicalUrl(file.toString(), req));
+        }
       }
-    });
+    );
   });
 
   app.get('/', (req, res) => {
-    fs.readFile(path.resolve(compiler.outputPath, 'index.html'), (err, file) => {
-      if (err) {
-        res.sendStatus(404);
-      } else {
-        res.send(file.toString());
+    outputFileSystem.readFile(
+      path.resolve(compiler.outputPath, 'index.html'),
+      (err, file) => {
+        if (err) {
+          res.sendStatus(404);
+        } else {
+          res.send(file.toString());
+        }
       }
-    });
+    );
   });
 };

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -66,6 +66,10 @@ function sendReportHtml(outputFileSystem, outputPath, req, res) {
   );
 }
 
+function getTrailingSlashUrl(req) {
+  return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
+}
+
 module.exports = function addDevMiddlewares(app, webpackConfig) {
   // 開発中はwebpackのビルド結果をディスクではなくメモリ上に作る。
   const compiler = webpack(webpackConfig);
@@ -94,8 +98,12 @@ module.exports = function addDevMiddlewares(app, webpackConfig) {
   // ディスク上のdistではなく、middlewareが持つファイルシステムからHTMLを読む。
   const outputFileSystem = middleware.context.outputFileSystem;
 
-  // /variant, /gene, /disease も同じHTMLを使い、canonicalだけURLごとに差し替える。
+  // /variant, /gene, /disease は末尾スラッシュ付きURLへ統一する。
   app.get('/:report(variant|gene|disease)/?', (req, res) => {
+    if (!req.path.endsWith('/')) {
+      return res.redirect(302, getTrailingSlashUrl(req));
+    }
+
     sendReportHtml(outputFileSystem, compiler.outputPath, req, res);
   });
 

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -12,14 +12,43 @@ function createWebpackMiddleware(compiler, publicPath) {
   });
 }
 
+function escapeHtmlAttribute(value) {
+  return value.replace(/["&<>]/g, (char) => {
+    switch (char) {
+      case '"':
+        return '&quot;';
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      default:
+        return char;
+    }
+  });
+}
+
+function getTrustedDevOrigin(req) {
+  const protocol = req.protocol === 'https' ? 'https' : 'http';
+  const port =
+    req.socket && typeof req.socket.localPort === 'number'
+      ? `:${req.socket.localPort}`
+      : '';
+
+  return `${protocol}://localhost${port}`;
+}
+
 function getCanonicalUrl(req) {
-  const protocol = req.get('x-forwarded-proto') || req.protocol;
-  return `${protocol}://${req.get('host')}${req.originalUrl.split('?')[0]}`;
+  return `${getTrustedDevOrigin(req)}${req.originalUrl.split('?')[0]}`;
 }
 
 // 詳細ページ用HTML内のプレースホルダーを、アクセスされたURL自身のcanonicalへ置き換える。
 function withCanonicalUrl(html, req) {
-  return html.replace(/__TOGOVAR_CANONICAL_URL__/g, getCanonicalUrl(req));
+  return html.replace(
+    /__TOGOVAR_CANONICAL_URL__/g,
+    escapeHtmlAttribute(getCanonicalUrl(req))
+  );
 }
 
 module.exports = function addDevMiddlewares(app, webpackConfig) {

--- a/app/frontend/server/middlewares/addDevMiddlewares.js
+++ b/app/frontend/server/middlewares/addDevMiddlewares.js
@@ -4,28 +4,16 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
+const {
+  withCanonicalUrl,
+  getTrailingSlashUrl,
+  getNoTrailingSlashUrl,
+} = require('./middlewareHelpers');
 
 function createWebpackMiddleware(compiler, publicPath) {
   return webpackDevMiddleware(compiler, {
     publicPath,
     stats: 'errors-only',
-  });
-}
-
-function escapeHtmlAttribute(value) {
-  return value.replace(/["&<>]/g, (char) => {
-    switch (char) {
-      case '"':
-        return '&quot;';
-      case '&':
-        return '&amp;';
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      default:
-        return char;
-    }
   });
 }
 
@@ -44,15 +32,6 @@ function getCanonicalUrl(req) {
 }
 
 // 詳細ページ用HTML内のプレースホルダーを、アクセスされたURL自身のcanonicalへ置き換える。
-function withCanonicalUrl(html, req) {
-  const canonicalUrl = escapeHtmlAttribute(getCanonicalUrl(req));
-
-  return html.replace(
-    /__TOGOVAR_CANONICAL_URL__/g,
-    () => canonicalUrl
-  );
-}
-
 function sendReportHtml(outputFileSystem, outputPath, req, res) {
   outputFileSystem.readFile(
     path.resolve(outputPath, req.params.report, 'index.html'),
@@ -60,19 +39,10 @@ function sendReportHtml(outputFileSystem, outputPath, req, res) {
       if (err) {
         res.sendStatus(404);
       } else {
-        res.send(withCanonicalUrl(file.toString(), req));
+        res.send(withCanonicalUrl(file.toString(), getCanonicalUrl(req)));
       }
     }
   );
-}
-
-function getTrailingSlashUrl(req) {
-  return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
-}
-
-function getNoTrailingSlashUrl(req) {
-  const queryString = req.originalUrl.slice(req.path.length);
-  return `${req.path.replace(/\/+$/, '')}${queryString}`;
 }
 
 module.exports = function addDevMiddlewares(app, webpackConfig) {

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -79,6 +79,10 @@ function sendReportHtml(outputPath, req, res) {
   });
 }
 
+function getTrailingSlashUrl(req) {
+  return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
+}
+
 // 本番環境用のExpressミドルウェアを追加する。
 // dist配下のビルド済みファイルを配信し、レポート詳細ページだけcanonicalを差し替えて返す。
 module.exports = function addProdMiddlewares(app, options) {
@@ -89,8 +93,12 @@ module.exports = function addProdMiddlewares(app, options) {
   // HTMLだけでなく、CSS/JSなどの静的アセットにも適用される。
   app.use(compression());
 
-  // /variant, /gene, /disease もcanonicalを差し替えて返す。
+  // /variant, /gene, /disease は末尾スラッシュ付きURLへ統一する。
   app.get('/:report(variant|gene|disease)/?', (req, res) => {
+    if (!req.path.endsWith('/')) {
+      return res.redirect(301, getTrailingSlashUrl(req));
+    }
+
     sendReportHtml(outputPath, req, res);
   });
 

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -40,9 +40,11 @@ function getCanonicalUrl(req) {
 // ビルド済みHTML内のプレースホルダーを、実際にアクセスされたURLへ置き換える。
 // /variant/:id, /gene/:id, /disease/:id は同じHTMLを使い回すため、ここでcanonicalを個別化する。
 function withCanonicalUrl(html, req) {
+  const canonicalUrl = escapeHtmlAttribute(getCanonicalUrl(req));
+
   return html.replace(
     /__TOGOVAR_CANONICAL_URL__/g,
-    escapeHtmlAttribute(getCanonicalUrl(req))
+    () => canonicalUrl
   );
 }
 

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -2,6 +2,11 @@ const path = require('path');
 const express = require('express');
 const compression = require('compression');
 const fs = require('fs');
+const {
+  withCanonicalUrl,
+  getTrailingSlashUrl,
+  getNoTrailingSlashUrl,
+} = require('./middlewareHelpers');
 
 const SITE_ORIGINS = {
   GRCh37: 'https://grch37.togovar.org',
@@ -17,38 +22,10 @@ function getSiteOrigin() {
   return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
 }
 
-function escapeHtmlAttribute(value) {
-  return value.replace(/["&<>]/g, (char) => {
-    switch (char) {
-      case '"':
-        return '&quot;';
-      case '&':
-        return '&amp;';
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      default:
-        return char;
-    }
-  });
-}
-
 // 信頼済みの設定値からcanonical URLを組み立てる。
 // Hostやx-forwarded-protoなどのリクエストヘッダーは、canonicalには使わない。
 function getCanonicalUrl(req) {
   return `${getSiteOrigin()}${req.originalUrl.split('?')[0]}`;
-}
-
-// ビルド済みHTML内のプレースホルダーを、実際にアクセスされたURLへ置き換える。
-// /variant/:id, /gene/:id, /disease/:id は同じHTMLを使い回すため、ここでcanonicalを個別化する。
-function withCanonicalUrl(html, req) {
-  const canonicalUrl = escapeHtmlAttribute(getCanonicalUrl(req));
-
-  return html.replace(
-    /__TOGOVAR_CANONICAL_URL__/g,
-    () => canonicalUrl
-  );
 }
 
 // 本番のビルド済みHTMLはデプロイ中に変わらない前提なので、初回読み込み後はメモリに保持する。
@@ -79,17 +56,8 @@ function sendReportHtml(outputPath, req, res) {
     }
 
     res.setHeader('Cache-Control', 'no-cache');
-    return res.send(withCanonicalUrl(html, req));
+    return res.send(withCanonicalUrl(html, getCanonicalUrl(req)));
   });
-}
-
-function getTrailingSlashUrl(req) {
-  return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
-}
-
-function getNoTrailingSlashUrl(req) {
-  const queryString = req.originalUrl.slice(req.path.length);
-  return `${req.path.replace(/\/+$/, '')}${queryString}`;
 }
 
 function isLongTermCacheAsset(filePath) {

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -16,6 +16,11 @@ function withCanonicalUrl(html, req) {
   return html.replace(/__TOGOVAR_CANONICAL_URL__/g, getCanonicalUrl(req));
 }
 
+// レポート種別に対応するビルド済みHTMLを非同期で読み込む。
+function readReportHtml(outputPath, report, callback) {
+  fs.readFile(path.resolve(outputPath, report, 'index.html'), 'utf8', callback);
+}
+
 // 本番環境用のExpressミドルウェアを追加する。
 // dist配下のビルド済みファイルを配信し、レポート詳細ページだけcanonicalを差し替えて返す。
 module.exports = function addProdMiddlewares(app, options) {
@@ -27,17 +32,15 @@ module.exports = function addProdMiddlewares(app, options) {
   app.use(compression());
   app.use(publicPath, express.static(outputPath));
 
-  // 詳細ページはURLごとにcanonicalが違うため、sendFileではなくHTML文字列を読み込んで差し替える。
+  // 詳細ページはURLごとにcanonicalが違うため、HTML文字列を読み込んで差し替える。
   app.get('/:report(variant|gene|disease)/:id', (req, res) => {
-    return res.send(
-      withCanonicalUrl(
-        fs.readFileSync(
-          path.resolve(outputPath, req.params.report, 'index.html'),
-          'utf8'
-        ),
-        req
-      )
-    );
+    readReportHtml(outputPath, req.params.report, (err, html) => {
+      if (err) {
+        return res.sendStatus(err.code === 'ENOENT' ? 404 : 500);
+      }
+
+      return res.send(withCanonicalUrl(html, req));
+    });
   });
 
   // トップページはビルド済みの dist/index.html をそのまま返す。

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -8,6 +8,8 @@ const SITE_ORIGINS = {
   GRCh38: 'https://grch38.togovar.org',
 };
 
+const reportHtmlCache = new Map();
+
 function getSiteOrigin() {
   return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
 }
@@ -44,13 +46,29 @@ function withCanonicalUrl(html, req) {
   );
 }
 
-// レポート種別に対応するビルド済みHTMLを非同期で読み込む。
-function readReportHtml(outputPath, report, callback) {
-  fs.readFile(path.resolve(outputPath, report, 'index.html'), 'utf8', callback);
+// 本番のビルド済みHTMLはデプロイ中に変わらない前提なので、初回読み込み後はメモリに保持する。
+function getReportHtml(outputPath, report, callback) {
+  const htmlPath = path.resolve(outputPath, report, 'index.html');
+  const cachedHtml = reportHtmlCache.get(htmlPath);
+
+  if (cachedHtml) {
+    callback(null, cachedHtml);
+    return;
+  }
+
+  fs.readFile(htmlPath, 'utf8', (err, html) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    reportHtmlCache.set(htmlPath, html);
+    callback(null, html);
+  });
 }
 
 function sendReportHtml(outputPath, req, res) {
-  readReportHtml(outputPath, req.params.report, (err, html) => {
+  getReportHtml(outputPath, req.params.report, (err, html) => {
     if (err) {
       return res.sendStatus(err.code === 'ENOENT' ? 404 : 500);
     }

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -2,25 +2,17 @@ const path = require('path');
 const express = require('express');
 const compression = require('compression');
 const fs = require('fs');
+const { getSiteOrigin } = require('../../config/siteOrigin');
 const {
   withCanonicalUrl,
   getTrailingSlashUrl,
   getNoTrailingSlashUrl,
 } = require('./middlewareHelpers');
 
-const SITE_ORIGINS = {
-  GRCh37: 'https://grch37.togovar.org',
-  GRCh38: 'https://grch38.togovar.org',
-};
-
 const reportHtmlCache = new Map();
 const LONG_TERM_CACHE_PATTERN =
   /\.(?:css|js|woff2?|eot|ttf|otf|png|jpe?g|gif|svg|webp)(?:\.gz)?$/i;
 const LONG_TERM_CACHE_DIRECTORY_PATTERN = /(?:^|\/)(?:css|js|fonts|images)\//;
-
-function getSiteOrigin() {
-  return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
-}
 
 // 信頼済みの設定値からcanonical URLを組み立てる。
 // Hostやx-forwarded-protoなどのリクエストヘッダーは、canonicalには使わない。

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -100,9 +100,4 @@ module.exports = function addProdMiddlewares(app, options) {
   });
 
   app.use(publicPath, express.static(outputPath));
-
-  // トップページはビルド済みの dist/index.html をそのまま返す。
-  app.get('/', (req, res) => {
-    return res.sendFile(path.resolve(outputPath, 'index.html'));
-  });
 };

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -10,7 +10,8 @@ const SITE_ORIGINS = {
 
 const reportHtmlCache = new Map();
 const LONG_TERM_CACHE_PATTERN =
-  /\.(?:css|js|woff2?|eot|ttf|otf|png|jpe?g|gif|svg|webp|jsonld)$/i;
+  /\.(?:css|js|woff2?|eot|ttf|otf|png|jpe?g|gif|svg|webp)(?:\.gz)?$/i;
+const LONG_TERM_CACHE_DIRECTORY_PATTERN = /(?:^|\/)(?:css|js|fonts|images)\//;
 
 function getSiteOrigin() {
   return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
@@ -92,7 +93,12 @@ function getNoTrailingSlashUrl(req) {
 }
 
 function isLongTermCacheAsset(filePath) {
-  return LONG_TERM_CACHE_PATTERN.test(filePath);
+  const normalizedPath = filePath.split(path.sep).join('/');
+
+  return (
+    LONG_TERM_CACHE_DIRECTORY_PATTERN.test(normalizedPath) &&
+    LONG_TERM_CACHE_PATTERN.test(normalizedPath)
+  );
 }
 
 function setStaticAssetCacheHeaders(res, filePath) {

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -3,17 +3,45 @@ const express = require('express');
 const compression = require('compression');
 const fs = require('fs');
 
-// リクエストされたURL自身をcanonical URLとして組み立てる。
-// reverse proxy配下では x-forwarded-proto を優先し、https/http の判定を合わせる。
+const SITE_ORIGINS = {
+  GRCh37: 'https://grch37.togovar.org',
+  GRCh38: 'https://grch38.togovar.org',
+};
+
+function getSiteOrigin() {
+  return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
+}
+
+function escapeHtmlAttribute(value) {
+  return value.replace(/["&<>]/g, (char) => {
+    switch (char) {
+      case '"':
+        return '&quot;';
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      default:
+        return char;
+    }
+  });
+}
+
+// 信頼済みの設定値からcanonical URLを組み立てる。
+// Hostやx-forwarded-protoなどのリクエストヘッダーは、canonicalには使わない。
 function getCanonicalUrl(req) {
-  const protocol = req.get('x-forwarded-proto') || req.protocol;
-  return `${protocol}://${req.get('host')}${req.originalUrl.split('?')[0]}`;
+  return `${getSiteOrigin()}${req.originalUrl.split('?')[0]}`;
 }
 
 // ビルド済みHTML内のプレースホルダーを、実際にアクセスされたURLへ置き換える。
 // /variant/:id, /gene/:id, /disease/:id は同じHTMLを使い回すため、ここでcanonicalを個別化する。
 function withCanonicalUrl(html, req) {
-  return html.replace(/__TOGOVAR_CANONICAL_URL__/g, getCanonicalUrl(req));
+  return html.replace(
+    /__TOGOVAR_CANONICAL_URL__/g,
+    escapeHtmlAttribute(getCanonicalUrl(req))
+  );
 }
 
 // レポート種別に対応するビルド済みHTMLを非同期で読み込む。

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -1,22 +1,47 @@
 const path = require('path');
 const express = require('express');
 const compression = require('compression');
+const fs = require('fs');
 
+// リクエストされたURL自身をcanonical URLとして組み立てる。
+// reverse proxy配下では x-forwarded-proto を優先し、https/http の判定を合わせる。
+function getCanonicalUrl(req) {
+  const protocol = req.get('x-forwarded-proto') || req.protocol;
+  return `${protocol}://${req.get('host')}${req.originalUrl.split('?')[0]}`;
+}
+
+// ビルド済みHTML内のプレースホルダーを、実際にアクセスされたURLへ置き換える。
+// /variant/:id, /gene/:id, /disease/:id は同じHTMLを使い回すため、ここでcanonicalを個別化する。
+function withCanonicalUrl(html, req) {
+  return html.replace(/__TOGOVAR_CANONICAL_URL__/g, getCanonicalUrl(req));
+}
+
+// 本番環境用のExpressミドルウェアを追加する。
+// dist配下のビルド済みファイルを配信し、レポート詳細ページだけcanonicalを差し替えて返す。
 module.exports = function addProdMiddlewares(app, options) {
   const publicPath = options.publicPath || '/';
   const outputPath = options.outputPath || path.resolve(process.cwd(), 'dist');
 
-  // compression middleware compresses your server responses which makes them
-  // smaller (applies also to assets). You can read more about that technique
-  // and other good practices on official Express.js docs http://mxs.is/googmy
+  // レスポンスをgzip圧縮して転送サイズを小さくする。
+  // HTMLだけでなく、CSS/JSなどの静的アセットにも適用される。
   app.use(compression());
   app.use(publicPath, express.static(outputPath));
 
+  // 詳細ページはURLごとにcanonicalが違うため、sendFileではなくHTML文字列を読み込んで差し替える。
   app.get('/:report(variant|gene|disease)/:id', (req, res) => {
-    return res.sendFile(path.resolve(outputPath, req.params.report, 'index.html'))
+    return res.send(
+      withCanonicalUrl(
+        fs.readFileSync(
+          path.resolve(outputPath, req.params.report, 'index.html'),
+          'utf8'
+        ),
+        req
+      )
+    );
   });
 
+  // トップページはビルド済みの dist/index.html をそのまま返す。
   app.get('/', (req, res) => {
-    return res.sendFile(path.resolve(outputPath, 'index.html'))
+    return res.sendFile(path.resolve(outputPath, 'index.html'));
   });
 };

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -49,6 +49,16 @@ function readReportHtml(outputPath, report, callback) {
   fs.readFile(path.resolve(outputPath, report, 'index.html'), 'utf8', callback);
 }
 
+function sendReportHtml(outputPath, req, res) {
+  readReportHtml(outputPath, req.params.report, (err, html) => {
+    if (err) {
+      return res.sendStatus(err.code === 'ENOENT' ? 404 : 500);
+    }
+
+    return res.send(withCanonicalUrl(html, req));
+  });
+}
+
 // 本番環境用のExpressミドルウェアを追加する。
 // dist配下のビルド済みファイルを配信し、レポート詳細ページだけcanonicalを差し替えて返す。
 module.exports = function addProdMiddlewares(app, options) {
@@ -58,18 +68,18 @@ module.exports = function addProdMiddlewares(app, options) {
   // レスポンスをgzip圧縮して転送サイズを小さくする。
   // HTMLだけでなく、CSS/JSなどの静的アセットにも適用される。
   app.use(compression());
-  app.use(publicPath, express.static(outputPath));
+
+  // /variant, /gene, /disease もcanonicalを差し替えて返す。
+  app.get('/:report(variant|gene|disease)/?', (req, res) => {
+    sendReportHtml(outputPath, req, res);
+  });
 
   // 詳細ページはURLごとにcanonicalが違うため、HTML文字列を読み込んで差し替える。
   app.get('/:report(variant|gene|disease)/:id', (req, res) => {
-    readReportHtml(outputPath, req.params.report, (err, html) => {
-      if (err) {
-        return res.sendStatus(err.code === 'ENOENT' ? 404 : 500);
-      }
-
-      return res.send(withCanonicalUrl(html, req));
-    });
+    sendReportHtml(outputPath, req, res);
   });
+
+  app.use(publicPath, express.static(outputPath));
 
   // トップページはビルド済みの dist/index.html をそのまま返す。
   app.get('/', (req, res) => {

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -9,6 +9,8 @@ const SITE_ORIGINS = {
 };
 
 const reportHtmlCache = new Map();
+const LONG_TERM_CACHE_PATTERN =
+  /\.(?:css|js|woff2?|eot|ttf|otf|png|jpe?g|gif|svg|webp|jsonld)$/i;
 
 function getSiteOrigin() {
   return SITE_ORIGINS[process.env.TOGOVAR_REFERENCE] || SITE_ORIGINS.GRCh38;
@@ -75,12 +77,25 @@ function sendReportHtml(outputPath, req, res) {
       return res.sendStatus(err.code === 'ENOENT' ? 404 : 500);
     }
 
+    res.setHeader('Cache-Control', 'no-cache');
     return res.send(withCanonicalUrl(html, req));
   });
 }
 
 function getTrailingSlashUrl(req) {
   return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
+}
+
+function isLongTermCacheAsset(filePath) {
+  return LONG_TERM_CACHE_PATTERN.test(filePath);
+}
+
+function setStaticAssetCacheHeaders(res, filePath) {
+  if (isLongTermCacheAsset(filePath)) {
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  } else {
+    res.setHeader('Cache-Control', 'no-cache');
+  }
 }
 
 // 本番環境用のExpressミドルウェアを追加する。
@@ -107,5 +122,10 @@ module.exports = function addProdMiddlewares(app, options) {
     sendReportHtml(outputPath, req, res);
   });
 
-  app.use(publicPath, express.static(outputPath));
+  app.use(
+    publicPath,
+    express.static(outputPath, {
+      setHeaders: setStaticAssetCacheHeaders,
+    })
+  );
 };

--- a/app/frontend/server/middlewares/addProdMiddlewares.js
+++ b/app/frontend/server/middlewares/addProdMiddlewares.js
@@ -86,6 +86,11 @@ function getTrailingSlashUrl(req) {
   return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
 }
 
+function getNoTrailingSlashUrl(req) {
+  const queryString = req.originalUrl.slice(req.path.length);
+  return `${req.path.replace(/\/+$/, '')}${queryString}`;
+}
+
 function isLongTermCacheAsset(filePath) {
   return LONG_TERM_CACHE_PATTERN.test(filePath);
 }
@@ -119,6 +124,10 @@ module.exports = function addProdMiddlewares(app, options) {
 
   // 詳細ページはURLごとにcanonicalが違うため、HTML文字列を読み込んで差し替える。
   app.get('/:report(variant|gene|disease)/:id', (req, res) => {
+    if (req.path.endsWith('/')) {
+      return res.redirect(301, getNoTrailingSlashUrl(req));
+    }
+
     sendReportHtml(outputPath, req, res);
   });
 

--- a/app/frontend/server/middlewares/middlewareHelpers.js
+++ b/app/frontend/server/middlewares/middlewareHelpers.js
@@ -1,0 +1,74 @@
+/**
+ * dev・prod 両ミドルウェアで共通して使うヘルパー関数をまとめたモジュール。
+ * canonical URL の組み立てに必要な HTML エスケープ処理と、
+ * 末尾スラッシュの付け外しに使う URL 変換処理を提供する。
+ */
+
+/**
+ * HTML 属性値に埋め込む文字列を安全にエスケープする。
+ * XSS を防ぐため、二重引用符・アンパサンド・山括弧を HTML エンティティへ変換する。
+ *
+ * @param {string} value - エスケープ対象の文字列
+ * @returns {string} エスケープ済みの文字列
+ */
+function escapeHtmlAttribute(value) {
+  return value.replace(/["&<>]/g, (char) => {
+    switch (char) {
+      case '"':
+        return '&quot;';
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      default:
+        return char;
+    }
+  });
+}
+
+/**
+ * ビルド済み HTML 内の canonical URL プレースホルダーを実際の URL へ置き換える。
+ * `/variant/:id`・`/gene/:id`・`/disease/:id` は同じ HTML を使い回すため、
+ * リクエストごとに canonical を差し替えて返す。
+ *
+ * @param {string} html - プレースホルダーを含む HTML 文字列
+ * @param {string} canonicalUrl - 差し替える canonical URL（未エスケープ）
+ * @returns {string} canonical URL を埋め込んだ HTML 文字列
+ */
+function withCanonicalUrl(html, canonicalUrl) {
+  const escaped = escapeHtmlAttribute(canonicalUrl);
+  return html.replace(/__TOGOVAR_CANONICAL_URL__/g, () => escaped);
+}
+
+/**
+ * 末尾スラッシュなし URL を、末尾スラッシュあり URL へ変換する。
+ * `/variant`・`/gene`・`/disease` へのアクセスを `/variant/` 形式へ統一するときに使う。
+ * クエリ文字列はそのまま引き継ぐ。
+ *
+ * @param {import('express').Request} req - Express リクエストオブジェクト
+ * @returns {string} 末尾スラッシュを付加した URL 文字列
+ */
+function getTrailingSlashUrl(req) {
+  return `${req.path}/${req.originalUrl.slice(req.path.length)}`;
+}
+
+/**
+ * 末尾スラッシュあり URL を、末尾スラッシュなし URL へ変換する。
+ * `/:id/` へのアクセスを `/:id` 形式へ統一するときに使う。
+ * クエリ文字列はそのまま引き継ぐ。
+ *
+ * @param {import('express').Request} req - Express リクエストオブジェクト
+ * @returns {string} 末尾スラッシュを除去した URL 文字列
+ */
+function getNoTrailingSlashUrl(req) {
+  const queryString = req.originalUrl.slice(req.path.length);
+  return `${req.path.replace(/\/+$/, '')}${queryString}`;
+}
+
+module.exports = {
+  withCanonicalUrl,
+  getTrailingSlashUrl,
+  getNoTrailingSlashUrl,
+};

--- a/app/frontend/src/classes/FloatingInfo.ts
+++ b/app/frontend/src/classes/FloatingInfo.ts
@@ -310,8 +310,8 @@ export default class FloatingInfo {
 
     contentP.className = 'content';
     contentP.innerText = tooltip.content;
-    // URL がある項目だけ Read More リンクを追加する。
-    if (tooltip.url) contentP.appendChild(this.createAnchor(tooltip.url));
+    // URL がある項目だけ詳細リンクを追加する。
+    if (tooltip.url) contentP.appendChild(this.createAnchor(tooltip));
     template.appendChild(contentP);
 
     return template;
@@ -341,12 +341,13 @@ export default class FloatingInfo {
     return `tooltip-${id || 'unknown'}-${this.tooltipIdSequence}`;
   }
 
-  private createAnchor(url: string): HTMLAnchorElement {
+  private createAnchor(tooltip: TooltipEntry): HTMLAnchorElement {
     const anchor = document.createElement('a');
 
     anchor.className = 'url';
-    anchor.href = url;
+    anchor.href = tooltip.url || '';
     anchor.innerText = 'Read More';
+    anchor.setAttribute('aria-label', `Read more about ${tooltip.content}`);
 
     return anchor;
   }

--- a/app/frontend/src/classes/Results/ResultsColumnTemplates.ts
+++ b/app/frontend/src/classes/Results/ResultsColumnTemplates.ts
@@ -24,19 +24,19 @@ export const REF_ALT_SHOW_LENGTH = 4;
  */
 export const COLUMN_TEMPLATES = {
   togovar_id:
-    '<td class="togovar_id"><a class="hyper-text -internal" target="_blank"></a></td>',
+    '<td class="togovar_id"><a class="hyper-text -internal" target="_blank" rel="noopener noreferrer"></a></td>',
   refsnp_id:
-    '<td class="refsnp_id" data-remains=""><a target="_blank" class="hyper-text -external"></a></td>',
+    '<td class="refsnp_id" data-remains=""><a target="_blank" rel="noopener noreferrer" class="hyper-text -external"></a></td>',
   position:
     '<td class="position"><div class="chromosome-position"><div class="chromosome"></div><div class="coordinate"></div></div></td>',
   ref_alt:
     '<td class="ref_alt"><div class="ref-alt"><span class="ref" data-sum=""></span><span class="arrow"></span><span class="alt" data-sum=""><span class="sum"></span></span></div></td>',
   type: '<td class="type"><div class="variant-type"></div></td>',
-  gene: '<td class="gene" data-remains=""><a class="hyper-text -internal" target="_blank"></a></td>',
+  gene: '<td class="gene" data-remains=""><a class="hyper-text -internal" target="_blank" rel="noopener noreferrer"></a></td>',
   consequence:
     '<td class="consequence" data-remains=""><div class="consequence-item"></div></td>',
   clinical_significance:
-    '<td class="clinical_significance"><div class="clinical-significance" data-value=""></div><a class="hyper-text -internal" target="_blank"></a><span class="icon" data-remains="" data-mgend=""></span></td>',
+    '<td class="clinical_significance"><div class="clinical-significance" data-value=""></div><a class="hyper-text -internal" target="_blank" rel="noopener noreferrer"></a><span class="icon" data-remains="" data-mgend=""></span></td>',
   alphamissense:
     '<td class="alphamissense"><div class="variant-function" data-function=""></div></td>',
   sift: '<td class="sift"><div class="variant-function" data-function=""></div></td>',

--- a/app/frontend/src/classes/Results/ResultsColumnTemplates.ts
+++ b/app/frontend/src/classes/Results/ResultsColumnTemplates.ts
@@ -24,19 +24,19 @@ export const REF_ALT_SHOW_LENGTH = 4;
  */
 export const COLUMN_TEMPLATES = {
   togovar_id:
-    '<td class="togovar_id"><a href="" class="hyper-text -internal" target="_blank"></a></td>',
+    '<td class="togovar_id"><a class="hyper-text -internal" target="_blank"></a></td>',
   refsnp_id:
-    '<td class="refsnp_id" data-remains=""><a href="" target="_blank" class="hyper-text -external"></a></td>',
+    '<td class="refsnp_id" data-remains=""><a target="_blank" class="hyper-text -external"></a></td>',
   position:
     '<td class="position"><div class="chromosome-position"><div class="chromosome"></div><div class="coordinate"></div></div></td>',
   ref_alt:
     '<td class="ref_alt"><div class="ref-alt"><span class="ref" data-sum=""></span><span class="arrow"></span><span class="alt" data-sum=""><span class="sum"></span></span></div></td>',
   type: '<td class="type"><div class="variant-type"></div></td>',
-  gene: '<td class="gene" data-remains=""><a href="" class="hyper-text -internal" target="_blank"></a></td>',
+  gene: '<td class="gene" data-remains=""><a class="hyper-text -internal" target="_blank"></a></td>',
   consequence:
     '<td class="consequence" data-remains=""><div class="consequence-item"></div></td>',
   clinical_significance:
-    '<td class="clinical_significance"><div class="clinical-significance" data-value=""></div><a class="hyper-text -internal" href="" target="_blank"></a><span class="icon" data-remains="" data-mgend=""></span></td>',
+    '<td class="clinical_significance"><div class="clinical-significance" data-value=""></div><a class="hyper-text -internal" target="_blank"></a><span class="icon" data-remains="" data-mgend=""></span></td>',
   alphamissense:
     '<td class="alphamissense"><div class="variant-function" data-function=""></div></td>',
   sift: '<td class="sift"><div class="variant-function" data-function=""></div></td>',

--- a/app/frontend/src/classes/Results/ResultsColumnUpdater.ts
+++ b/app/frontend/src/classes/Results/ResultsColumnUpdater.ts
@@ -12,18 +12,24 @@ import type {
 import { REF_ALT_SHOW_LENGTH } from './ResultsColumnTemplates';
 
 /**
- * Utility class responsible for updating data in each column of result rows
+ * 検索結果テーブルの各列に、バリアント情報を反映するためのユーティリティクラス。
  *
- * Each method is implemented as a static method and is responsible for updating
- * DOM elements of specific column types with corresponding data
+ * 各メソッドは列ごとのDOM要素を受け取り、表示テキスト、リンク先、
+ * 補助情報用のdata属性などを更新する。
  */
 export class ResultsColumnUpdater {
+  /**
+   * リンクとして表示する内容がない場合に、a要素を空の状態へ戻す。
+   */
   static resetAnchor(element: HTMLAnchorElement) {
     element.removeAttribute('href');
     element.removeAttribute('aria-label');
     element.textContent = '';
   }
 
+  /**
+   * a要素にリンク先、表示文字列、スクリーンリーダー向けラベルを設定する。
+   */
   static updateAnchor(
     element: HTMLAnchorElement,
     url: string,
@@ -36,11 +42,11 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update TogoVar ID column
+   * TogoVar ID列を更新する。
    *
-   * @param element - Target anchor element to update
-   * @param value - TogoVar ID value
-   * @param url - Link destination URL
+   * @param element - 更新対象のa要素
+   * @param value - 表示するTogoVar ID
+   * @param url - バリアント詳細ページのURL
    */
   static updateTogovarId(
     element: HTMLAnchorElement | null,
@@ -58,11 +64,11 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update RefSNP ID column
+   * RefSNP ID列を更新する。
    *
-   * @param tdRS - RefSNP table cell element
-   * @param tdRSAnchor - RefSNP anchor element
-   * @param values - RefSNP ID array
+   * @param tdRS - RefSNP列のtd要素
+   * @param tdRSAnchor - RefSNP IDを表示するa要素
+   * @param values - RefSNP IDの配列
    */
   static updateRefSNP(
     tdRS: HTMLTableCellElement | null,
@@ -77,22 +83,23 @@ export class ResultsColumnUpdater {
       return;
     }
 
+    // 画面には先頭のrsIDだけを表示し、残りの件数はdata-remainsに保持する。
     tdRS.dataset.remains = (values.length - 1).toString();
     this.updateAnchor(
       tdRSAnchor,
-      `http://identifiers.org/dbsnp/${values[0]}`,
+      `https://identifiers.org/dbsnp/${values[0]}`,
       values[0],
       `Open dbSNP record ${values[0]}`
     );
   }
 
   /**
-   * Update Position column
+   * Position列を更新する。
    *
-   * @param tdPositionChromosome - Div element for chromosome display
-   * @param tdPositionCoordinate - Div element for coordinate display
-   * @param chromosome - Chromosome name
-   * @param position - Coordinate position
+   * @param tdPositionChromosome - 染色体名を表示するdiv要素
+   * @param tdPositionCoordinate - 座標を表示するdiv要素
+   * @param chromosome - 染色体名
+   * @param position - ゲノム上の座標
    */
   static updatePosition(
     tdPositionChromosome: HTMLDivElement | null,
@@ -109,12 +116,12 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update Ref/Alt column
+   * Ref/Alt列を更新する。
    *
-   * @param tdRefAltRef - Span element for Reference display
-   * @param tdRefAltAlt - Span element for Alternate display
-   * @param reference - Reference allele array
-   * @param alternate - Alternate allele array
+   * @param tdRefAltRef - Reference alleleを表示するspan要素
+   * @param tdRefAltAlt - Alternate alleleを表示するspan要素
+   * @param reference - Reference allele
+   * @param alternate - Alternate allele
    */
   static updateRefAlt(
     tdRefAltRef: HTMLSpanElement | null,
@@ -137,10 +144,10 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Generate formatting information for Ref/Alt data
+   * Ref/Alt表示用の文字列と、元の長さを生成する。
    *
-   * @param sequence - Sequence string to format
-   * @returns Object containing display string and original length
+   * @param sequence - 整形対象の塩基配列
+   * @returns 表示文字列と元の文字数
    */
   static formatRefAltData(sequence: string) {
     return {
@@ -150,11 +157,11 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Format Ref/Alt sequence for display
-   * Adds ellipsis if sequence exceeds specified length
+   * Ref/Altの塩基配列を表示用に整形する。
+   * 長すぎる場合は、指定文字数で省略して末尾に...を付ける。
    *
-   * @param sequence - Sequence string to format
-   * @returns Formatted string
+   * @param sequence - 整形対象の塩基配列
+   * @returns 整形後の表示文字列
    */
   static formatRefAlt(sequence: string) {
     return (
@@ -164,10 +171,10 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update Variant Type column
+   * Variant Type列を更新する。
    *
-   * @param element - Target Div element to update
-   * @param value - Variant type ID
+   * @param element - 更新対象のdiv要素
+   * @param value - バリアントタイプID
    */
   static updateVariantType(element: HTMLDivElement | null, value: string) {
     if (!element) return;
@@ -178,11 +185,11 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update Gene column
+   * Gene列を更新する。
    *
-   * @param tdGene - Gene table cell element
-   * @param tdGeneAnchor - Gene anchor element
-   * @param symbols - Gene symbol array
+   * @param tdGene - Gene列のtd要素
+   * @param tdGeneAnchor - Gene名を表示するa要素
+   * @param symbols - 遺伝子シンボルの配列
    */
   static updateGene(
     tdGene: HTMLTableCellElement | null,
@@ -197,6 +204,7 @@ export class ResultsColumnUpdater {
       return;
     }
 
+    // 画面には先頭の遺伝子だけを表示し、残りの件数はdata-remainsに保持する。
     tdGene.dataset.remains = (symbols.length - 1).toString();
     this.updateAnchor(
       tdGeneAnchor,
@@ -207,10 +215,10 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update Alt frequency column
+   * Alt frequency列を更新する。
    *
-   * @param tdFrequencies - Map of frequency display elements
-   * @param frequencies - Frequency data array
+   * @param tdFrequencies - データセットIDごとの頻度表示要素
+   * @param frequencies - 頻度データの配列
    */
   static updateAltFrequency(
     tdFrequencies: TdFrequencies,
@@ -233,12 +241,12 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update Consequence column
+   * Consequence列を更新する。
    *
-   * @param tdConsequence - Consequence table cell element
-   * @param tdConsequenceItem - Consequence display Div element
-   * @param mostConsequence - Most significant consequence
-   * @param transcripts - Transcript data array
+   * @param tdConsequence - Consequence列のtd要素
+   * @param tdConsequenceItem - Consequence名を表示するdiv要素
+   * @param mostConsequence - 最も重要なConsequence ID
+   * @param transcripts - Transcript情報の配列
    */
   static updateConsequence(
     tdConsequence: HTMLTableCellElement | null,
@@ -267,12 +275,12 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update Clinical significance column
+   * Clinical significance列を更新する。
    *
-   * @param tdClinicalSign - Clinical significance display Div element
-   * @param tdClinicalAnchor - Clinical significance anchor element
-   * @param tdClinicalIcon - Clinical significance icon Span element
-   * @param significances - Clinical significance data array
+   * @param tdClinicalSign - Clinical significanceを表示するdiv要素
+   * @param tdClinicalAnchor - 疾患名をリンク表示するa要素
+   * @param tdClinicalIcon - 追加情報の有無を示すspan要素
+   * @param significances - Clinical significance情報の配列
    */
   static updateClinicalSignificance(
     tdClinicalSign: HTMLDivElement | null,
@@ -294,7 +302,7 @@ export class ResultsColumnUpdater {
     const firstSignificance = significances[0];
     const firstCondition = firstSignificance.conditions?.[0];
 
-    // Set interpretations value
+    // interpretationの値は、色分けなどの表示制御に使う。
     tdClinicalSign.dataset.value = firstSignificance.interpretations[0];
 
     this.updateClinicalCondition(
@@ -306,11 +314,11 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Reset Clinical significance processing
+   * Clinical significance列を空の状態へ戻す。
    *
-   * @param tdClinicalSign - Clinical significance display Div element
-   * @param tdClinicalAnchor - Clinical significance anchor element
-   * @param tdClinicalIcon - Clinical significance icon Span element
+   * @param tdClinicalSign - Clinical significanceを表示するdiv要素
+   * @param tdClinicalAnchor - 疾患名をリンク表示するa要素
+   * @param tdClinicalIcon - 追加情報の有無を示すspan要素
    */
   static resetClinicalSignificance(
     tdClinicalSign: HTMLDivElement,
@@ -324,11 +332,11 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update Clinical significance condition information
+   * Clinical significanceに紐づく疾患情報を更新する。
    *
-   * @param tdClinicalSign - Clinical significance display Div element
-   * @param tdClinicalAnchor - Clinical significance anchor element
-   * @param firstCondition - First condition data
+   * @param tdClinicalSign - Clinical significanceを表示するdiv要素
+   * @param tdClinicalAnchor - 疾患名をリンク表示するa要素
+   * @param firstCondition - 先頭の疾患情報
    */
   static updateClinicalCondition(
     tdClinicalSign: HTMLDivElement,
@@ -346,31 +354,31 @@ export class ResultsColumnUpdater {
           `View disease ${firstCondition.name} details`
         );
       } else {
-        // Display in div instead of anchor when no medgen
+        // MedGen IDがない場合はリンクにせず、通常テキストとして表示する。
         tdClinicalSign.textContent = firstCondition.name;
         this.resetAnchor(tdClinicalAnchor);
       }
     } else {
-      // No conditions exist
+      // 疾患情報がない場合はothersとして表示する。
       tdClinicalSign.textContent = 'others';
       this.resetAnchor(tdClinicalAnchor);
     }
   }
 
   /**
-   * Update Clinical significance metadata
+   * Clinical significance列の補助情報を更新する。
    *
-   * @param tdClinicalIcon - Clinical significance icon Span element
-   * @param significances - Clinical significance data array
+   * @param tdClinicalIcon - 追加情報の有無を示すspan要素
+   * @param significances - Clinical significance情報の配列
    */
   static updateClinicalMetadata(
     tdClinicalIcon: HTMLSpanElement,
     significances: Significance[]
   ) {
-    // Set remaining significance count
+    // 画面に表示している先頭1件以外の件数を保持する。
     tdClinicalIcon.dataset.remains = (significances.length - 1).toString();
 
-    // Check if mgend source exists in significances
+    // MGeND由来の情報が含まれるかを保持する。
     const hasMedgen = significances.some(
       (significance) => significance.source === 'mgend'
     );
@@ -378,11 +386,11 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Common update logic for function prediction
+   * 機能予測スコア列の共通更新処理。
    *
-   * @param element - Target Div element to update
-   * @param score - Function prediction score value
-   * @param classifyScore - Function to determine function class from score value
+   * @param element - 更新対象のdiv要素
+   * @param score - 機能予測スコア
+   * @param classifyScore - スコアから表示用クラスを判定する関数
    */
   static updateFunctionPrediction(
     element: HTMLDivElement | null,
@@ -402,10 +410,10 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update AlphaMissense score
+   * AlphaMissenseスコアを更新する。
    *
-   * @param element - Target Div element to update
-   * @param score - AlphaMissense score
+   * @param element - 更新対象のdiv要素
+   * @param score - AlphaMissenseスコア
    */
   static updateAlphaMissense(element: HTMLDivElement | null, score: number) {
     this.updateFunctionPrediction(element, score, (_score) => {
@@ -416,10 +424,10 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update SIFT score
+   * SIFTスコアを更新する。
    *
-   * @param element - Target Div element to update
-   * @param score - SIFT score
+   * @param element - 更新対象のdiv要素
+   * @param score - SIFTスコア
    */
   static updateSift(element: HTMLDivElement | null, score: number) {
     this.updateFunctionPrediction(element, score, (_score) =>
@@ -428,10 +436,10 @@ export class ResultsColumnUpdater {
   }
 
   /**
-   * Update PolyPhen score
+   * PolyPhenスコアを更新する。
    *
-   * @param element - Target Div element to update
-   * @param score - PolyPhen score
+   * @param element - 更新対象のdiv要素
+   * @param score - PolyPhenスコア
    */
   static updatePolyphen(element: HTMLDivElement | null, score: number) {
     this.updateFunctionPrediction(element, score, (_score) => {

--- a/app/frontend/src/classes/Results/ResultsColumnUpdater.ts
+++ b/app/frontend/src/classes/Results/ResultsColumnUpdater.ts
@@ -18,6 +18,23 @@ import { REF_ALT_SHOW_LENGTH } from './ResultsColumnTemplates';
  * DOM elements of specific column types with corresponding data
  */
 export class ResultsColumnUpdater {
+  static resetAnchor(element: HTMLAnchorElement) {
+    element.removeAttribute('href');
+    element.removeAttribute('aria-label');
+    element.textContent = '';
+  }
+
+  static updateAnchor(
+    element: HTMLAnchorElement,
+    url: string,
+    text: string,
+    label: string
+  ) {
+    element.setAttribute('href', url);
+    element.textContent = text;
+    element.setAttribute('aria-label', label);
+  }
+
   /**
    * Update TogoVar ID column
    *
@@ -32,14 +49,12 @@ export class ResultsColumnUpdater {
   ) {
     if (!element || !value) {
       if (element) {
-        element.href = '';
-        element.textContent = '';
+        this.resetAnchor(element);
       }
       return;
     }
 
-    element.href = url;
-    element.textContent = value;
+    this.updateAnchor(element, url, value, `View variant ${value} details`);
   }
 
   /**
@@ -58,14 +73,17 @@ export class ResultsColumnUpdater {
 
     if (!values || values.length === 0) {
       tdRS.dataset.remains = '0';
-      tdRSAnchor.href = '';
-      tdRSAnchor.textContent = '';
+      this.resetAnchor(tdRSAnchor);
       return;
     }
 
     tdRS.dataset.remains = (values.length - 1).toString();
-    tdRSAnchor.href = `http://identifiers.org/dbsnp/${values[0]}`;
-    tdRSAnchor.textContent = values[0];
+    this.updateAnchor(
+      tdRSAnchor,
+      `http://identifiers.org/dbsnp/${values[0]}`,
+      values[0],
+      `Open dbSNP record ${values[0]}`
+    );
   }
 
   /**
@@ -175,14 +193,17 @@ export class ResultsColumnUpdater {
 
     if (!symbols || symbols.length === 0) {
       tdGene.dataset.remains = '0';
-      tdGeneAnchor.href = '';
-      tdGeneAnchor.textContent = '';
+      this.resetAnchor(tdGeneAnchor);
       return;
     }
 
     tdGene.dataset.remains = (symbols.length - 1).toString();
-    tdGeneAnchor.href = `/gene/${symbols[0].id}`;
-    tdGeneAnchor.textContent = symbols[0].name;
+    this.updateAnchor(
+      tdGeneAnchor,
+      `/gene/${symbols[0].id}`,
+      symbols[0].name,
+      `View gene ${symbols[0].name} details`
+    );
   }
 
   /**
@@ -297,8 +318,7 @@ export class ResultsColumnUpdater {
     tdClinicalIcon: HTMLSpanElement
   ) {
     tdClinicalSign.dataset.value = '';
-    tdClinicalAnchor.textContent = '';
-    tdClinicalAnchor.setAttribute('href', '');
+    this.resetAnchor(tdClinicalAnchor);
     tdClinicalIcon.dataset.remains = '0';
     tdClinicalIcon.dataset.mgend = 'false';
   }
@@ -317,23 +337,23 @@ export class ResultsColumnUpdater {
   ) {
     if (firstCondition) {
       tdClinicalSign.textContent = '';
-      tdClinicalAnchor.textContent = firstCondition.name || '';
 
       if (firstCondition.medgen) {
-        tdClinicalAnchor.setAttribute(
-          'href',
-          `/disease/${firstCondition.medgen}`
+        this.updateAnchor(
+          tdClinicalAnchor,
+          `/disease/${firstCondition.medgen}`,
+          firstCondition.name || '',
+          `View disease ${firstCondition.name} details`
         );
       } else {
         // Display in div instead of anchor when no medgen
         tdClinicalSign.textContent = firstCondition.name;
-        tdClinicalAnchor.textContent = '';
-        tdClinicalAnchor.className = '';
+        this.resetAnchor(tdClinicalAnchor);
       }
     } else {
       // No conditions exist
       tdClinicalSign.textContent = 'others';
-      tdClinicalAnchor.textContent = '';
+      this.resetAnchor(tdClinicalAnchor);
     }
   }
 

--- a/app/frontend/src/components/ConditionItemValueView.ts
+++ b/app/frontend/src/components/ConditionItemValueView.ts
@@ -61,6 +61,8 @@ export class ConditionItemValueView extends LitElement {
             ? html`<button
                 class="delete"
                 part="delete-tag-btn"
+                type="button"
+                aria-label="Remove condition value"
                 @click=${this._handleDelete}
               ></button>`
             : nothing}

--- a/app/frontend/src/components/SearchField/SearchField.ts
+++ b/app/frontend/src/components/SearchField/SearchField.ts
@@ -122,6 +122,7 @@ class SearchField extends LitElement {
             <button
               class="delete"
               type="reset"
+              aria-label="Clear search input"
               @click=${this._handleResetClick}
             ></button>
           </form>

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchButton.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchButton.ts
@@ -14,6 +14,10 @@ export default class SearchButton extends LitElement {
   }
 
   render(): TemplateResult {
-    return html`<button class="btn"></button>`;
+    return html`<button
+      class="btn"
+      type="button"
+      aria-label="Search"
+    ></button>`;
   }
 }

--- a/app/frontend/stylesheets/foundation/_base.scss
+++ b/app/frontend/stylesheets/foundation/_base.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900');
-
 @mixin sprite($width, $height, $x, $y) {
   background-image: url('../images/csssprite.png');
   background-repeat: no-repeat;

--- a/app/frontend/stylesheets/object/component/_dataset-icon.sass
+++ b/app/frontend/stylesheets/object/component/_dataset-icon.sass
@@ -16,7 +16,7 @@
     flex-direction: column
     justify-content: center
     font-family: "Roboto Condensed"
-    font-weight: lighter
+    font-weight: normal
     line-height: 9px
     position: relative
     left: -2px

--- a/app/frontend/stylesheets/object/component/_hyper-text.sass
+++ b/app/frontend/stylesheets/object/component/_hyper-text.sass
@@ -1,22 +1,22 @@
 @use "sass:color"
 
 .hyper-text
-  &:not([href=""])
+  &[href]:not([href=""])
     &:after
       font-family: 'Font Awesome 7 Free', sans-serif
       font-weight: 900
       display: inline-block
       margin-left: .25em
       color: color.adjust($COLOR_GRAY, $lightness: 10%)
-  &:hover:after
+  &[href]:not([href=""]):hover:after
     color: $COLOR_KEY
   &.-internal
-    &:not([href=""])
+    &[href]:not([href=""])
       &:after
         content: var(--icon-circle-arrow-right)
         font-size: .8em
   &.-external
-    &:not([href=""])
+    &[href]:not([href=""])
       &:after
         content: var(--icon-arrow-up-right-from-square)
         font-size: .7em

--- a/app/frontend/views/disease/index.pug
+++ b/app/frontend/views/disease/index.pug
@@ -3,6 +3,7 @@ extend ../layouts/application
 append variables
   - locals.currentPage = "disease";
   - locals.description = "TogoVar disease report pages provide related variants, clinical significance, genome-wide association studies, and disease annotations.";
+  - locals.canonicalUrl = "__TOGOVAR_CANONICAL_URL__";
 
 block head
   each css in htmlWebpackPlugin.files.css.filter(x => x.match(/^\/css\/main-/))

--- a/app/frontend/views/disease/index.pug
+++ b/app/frontend/views/disease/index.pug
@@ -2,6 +2,7 @@ extend ../layouts/application
 
 append variables
   - locals.currentPage = "disease";
+  - locals.description = "TogoVar disease report pages provide related variants, clinical significance, genome-wide association studies, and disease annotations.";
 
 block head
   each css in htmlWebpackPlugin.files.css.filter(x => x.match(/^\/css\/main-/))

--- a/app/frontend/views/gene/index.pug
+++ b/app/frontend/views/gene/index.pug
@@ -3,6 +3,7 @@ extend ../layouts/application
 append variables
   - locals.currentPage = "gene";
   - locals.description = "TogoVar gene report pages provide variant annotations, clinical significance, genomic context, protein information, and publications for human genes.";
+  - locals.canonicalUrl = "__TOGOVAR_CANONICAL_URL__";
 
 block head
   each css in htmlWebpackPlugin.files.css.filter(x => x.match(/^\/css\/main-/))

--- a/app/frontend/views/gene/index.pug
+++ b/app/frontend/views/gene/index.pug
@@ -2,6 +2,7 @@ extend ../layouts/application
 
 append variables
   - locals.currentPage = "gene";
+  - locals.description = "TogoVar gene report pages provide variant annotations, clinical significance, genomic context, protein information, and publications for human genes.";
 
 block head
   each css in htmlWebpackPlugin.files.css.filter(x => x.match(/^\/css\/main-/))

--- a/app/frontend/views/index.pug
+++ b/app/frontend/views/index.pug
@@ -3,7 +3,7 @@ extend layouts/application
 append variables
   - locals.currentPage = "home";
   - locals.description = "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.";
-  - locals.canonicalUrl = TOGOVAR_FRONTEND_REFERENCE === "GRCh37" ? "https://grch37.togovar.org/" : "https://grch38.togovar.org/";
+  - locals.canonicalUrl = `${TOGOVAR_FRONTEND_SITE_ORIGIN}/`;
 
 block head
   link(href="/togovar.jsonld" rel="alternate" type="application/ld+json")

--- a/app/frontend/views/index.pug
+++ b/app/frontend/views/index.pug
@@ -3,6 +3,7 @@ extend layouts/application
 append variables
   - locals.currentPage = "home";
   - locals.description = "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.";
+  - locals.canonicalUrl = TOGOVAR_FRONTEND_REFERENCE === "GRCh37" ? "https://grch37.togovar.org/" : "https://grch38.togovar.org/";
 
 block head
   link(href="/togovar.jsonld" rel="alternate" type="application/ld+json")

--- a/app/frontend/views/index.pug
+++ b/app/frontend/views/index.pug
@@ -2,6 +2,7 @@ extend layouts/application
 
 append variables
   - locals.currentPage = "home";
+  - locals.description = "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.";
 
 block head
   link(href="/togovar.jsonld" rel="alternate" type="application/ld+json")

--- a/app/frontend/views/layouts/application.pug
+++ b/app/frontend/views/layouts/application.pug
@@ -10,9 +10,7 @@ html(data-page=locals.currentPage, lang=lang)
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1")
     meta(name="description" content=locals.description ? locals.description : "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.")
-    if typeof canonicalUrl !== "undefined"
-      link(rel="canonical" href=canonicalUrl)
-    else if locals.canonicalUrl
+    if locals.canonicalUrl
       link(rel="canonical" href=locals.canonicalUrl)
     link(rel="icon" href="/favicon.svg" type="image/svg+xml")
     script.

--- a/app/frontend/views/layouts/application.pug
+++ b/app/frontend/views/layouts/application.pug
@@ -10,6 +10,10 @@ html(data-page=locals.currentPage, lang=lang)
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1")
     meta(name="description" content=locals.description ? locals.description : "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.")
+    if typeof canonicalUrl !== "undefined"
+      link(rel="canonical" href=canonicalUrl)
+    else if locals.canonicalUrl
+      link(rel="canonical" href=locals.canonicalUrl)
     link(rel="icon" href="/favicon.svg" type="image/svg+xml")
     script.
       (async function() {

--- a/app/frontend/views/layouts/application.pug
+++ b/app/frontend/views/layouts/application.pug
@@ -9,6 +9,7 @@ html(data-page=locals.currentPage, lang=lang)
     title= locals.title ? locals.title : "TogoVar"
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1")
+    meta(name="description" content=locals.description ? locals.description : "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.")
     link(rel="icon" href="/favicon.svg" type="image/svg+xml")
     script.
       (async function() {

--- a/app/frontend/views/layouts/application.pug
+++ b/app/frontend/views/layouts/application.pug
@@ -10,8 +10,9 @@ html(data-page=locals.currentPage, lang=lang)
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1")
     meta(name="description" content=locals.description ? locals.description : "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.")
-    if locals.canonicalUrl
-      link(rel="canonical" href=locals.canonicalUrl)
+    - canonicalHref = locals.canonicalUrl || (typeof canonicalUrl !== "undefined" ? canonicalUrl : null)
+    if canonicalHref
+      link(rel="canonical" href=canonicalHref)
     link(rel="preconnect" href="https://fonts.googleapis.com")
     link(rel="preconnect" href="https://fonts.gstatic.com" crossorigin)
     link(href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700;900&display=swap" rel="stylesheet")

--- a/app/frontend/views/layouts/application.pug
+++ b/app/frontend/views/layouts/application.pug
@@ -12,6 +12,9 @@ html(data-page=locals.currentPage, lang=lang)
     meta(name="description" content=locals.description ? locals.description : "TogoVar is an integrated database of Japanese genomic variation, providing allele frequencies and annotations for human variants.")
     if locals.canonicalUrl
       link(rel="canonical" href=locals.canonicalUrl)
+    link(rel="preconnect" href="https://fonts.googleapis.com")
+    link(rel="preconnect" href="https://fonts.gstatic.com" crossorigin)
+    link(href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700;900&display=swap" rel="stylesheet")
     link(rel="icon" href="/favicon.svg" type="image/svg+xml")
     script.
       (async function() {

--- a/app/frontend/views/variant/index.pug
+++ b/app/frontend/views/variant/index.pug
@@ -2,6 +2,7 @@ extend ../layouts/application
 
 append variables
   - locals.currentPage = "variant";
+  - locals.description = "TogoVar variant report pages provide allele frequencies, clinical significance, consequences, genes, transcripts, publications, and genomic context for human variants.";
 
 block head
   each css in htmlWebpackPlugin.files.css.filter(x => x.match(/^\/css\/main-/))

--- a/app/frontend/views/variant/index.pug
+++ b/app/frontend/views/variant/index.pug
@@ -3,6 +3,7 @@ extend ../layouts/application
 append variables
   - locals.currentPage = "variant";
   - locals.description = "TogoVar variant report pages provide allele frequencies, clinical significance, consequences, genes, transcripts, publications, and genomic context for human variants.";
+  - locals.canonicalUrl = "__TOGOVAR_CANONICAL_URL__";
 
 block head
   each css in htmlWebpackPlugin.files.css.filter(x => x.match(/^\/css\/main-/))


### PR DESCRIPTION
[#419](https://github.com/togovar/togovar/pull/419)
seoに関して修正しました。

This pull request introduces several improvements focused on SEO optimization, dynamic canonical URL handling, and minor UI and code quality enhancements. The most significant changes are the automatic generation of `robots.txt` and `sitemap.xml` during the build, dynamic insertion of canonical URLs for detail pages, and improved metadata for search engines. Below are the most important changes grouped by theme:

**SEO and Static File Generation**
* Added a custom Webpack plugin (`StaticSeoFilesPlugin`) to automatically generate `robots.txt` and `sitemap.xml` files based on the build target and available documentation pages, ensuring up-to-date SEO files without manual maintenance. (`app/frontend/config/webpack.config.common.js`) [[1]](diffhunk://#diff-66b82c58c36317fc264bf9f27aea2129b125280236593ccdc053dcd5d75c2a3dR11-R87) [[2]](diffhunk://#diff-66b82c58c36317fc264bf9f27aea2129b125280236593ccdc053dcd5d75c2a3dR299-R350)
* Enhanced each page’s metadata by injecting a `description` and `canonicalUrl` variable, and updating the base layout to use these for `<meta name="description">` and `<link rel="canonical">` tags, improving search engine indexing and deduplication. (`app/frontend/views/layouts/application.pug`, `index.pug`, `variant/index.pug`, `gene/index.pug`, `disease/index.pug`) [[1]](diffhunk://#diff-cef096f8c53aef0e076ae73b2ac2dcd505ec90daba816c82b0a6d84d335beb30R12-R16) [[2]](diffhunk://#diff-921872612ff44444973b9ead364448a6dbeeb862c6c5163cdb8a7ab12dc13488R5-R6) [[3]](diffhunk://#diff-ec95e66f6972e2ff4527f24dfdf453b27687bb9c1b0d0bbc5225f6b1f8953f66R5-R6) [[4]](diffhunk://#diff-3489bfe0af372b6ed697f24ba23bb6661941578e712d85ba4c82ce9da5004e36R5-R6) [[5]](diffhunk://#diff-d27e7ef131d0eaf41465c60f1b4426b7e444a3c1bd5c8a4f9e44699b2c46efabR5-R6)

**Dynamic Canonical URL Handling**
* Implemented middleware logic for both development and production servers to replace a placeholder in detail page HTML with the actual canonical URL of the accessed resource, ensuring correct canonical tags for all `/variant/:id`, `/gene/:id`, and `/disease/:id` pages. (`app/frontend/server/middlewares/addDevMiddlewares.js`, `app/frontend/server/middlewares/addProdMiddlewares.js`) [[1]](diffhunk://#diff-e3e5a5512973d0839b10e8faca9129b16452a5e00ecd573063f5b7adb7b307deR15-R40) [[2]](diffhunk://#diff-e3e5a5512973d0839b10e8faca9129b16452a5e00ecd573063f5b7adb7b307deL37-R80) [[3]](diffhunk://#diff-34a08cfc3ac16c27ff775202c69c7930577a67cabd9aaa5d402ae6d66aab0796R4-R45)

**Accessibility and UI Minor Improvements**
* Improved the tooltip’s "Read More" link by adding an `aria-label` for better accessibility and passing the entire tooltip object for more context. (`app/frontend/src/classes/FloatingInfo.ts`) [[1]](diffhunk://#diff-fe27e92442333852572ad7587a552e9410ea2d629ec8b03da047b59d33c30024L313-R314) [[2]](diffhunk://#diff-fe27e92442333852572ad7587a552e9410ea2d629ec8b03da047b59d33c30024L344-R350)
* Adjusted the font weight in dataset icons from `lighter` to `normal` for better visual consistency. (`app/frontend/stylesheets/object/component/_dataset-icon.sass`)

**Linting/Code Quality**
* Updated ESLint configuration to disable the `@typescript-eslint/no-var-requires` rule for JavaScript files under `app/frontend/server/`, preventing unnecessary lint errors. (`.eslintrc.json`)