### PR TITLE
fix examples ui

### DIFF
--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchConstants.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchConstants.ts
@@ -8,7 +8,7 @@ declare const TOGOVAR_FRONTEND_REFERENCE: 'GRCh37' | 'GRCh38' | string;
 /** 検索例のアイテム型 */
 export interface ExampleItem {
   key: string;
-  value: string;
+  value: string | string[];
 }
 
 /** 検索フィールド設定の型 */
@@ -52,11 +52,7 @@ export const EXAMPLES: ExampleItem[] = (() => {
         },
         {
           key: 'HGVSc',
-          value: 'ALDH2:c.1510G>A',
-        },
-        {
-          key: 'HGVSc',
-          value: 'NM_000690:c.1510G>A',
+          value: ['ALDH2:c.1510G>A', 'NM_000690:c.1510G>A'],
         },
         {
           key: 'Chr:Position:Ref>Alt',
@@ -74,7 +70,7 @@ export const EXAMPLES: ExampleItem[] = (() => {
           key: 'Region',
           value: '12:112241766-112241766',
         },
-      {
+        {
           key: 'Disease',
           value: '"Alcohol sensitivity"',
         },
@@ -99,11 +95,7 @@ export const EXAMPLES: ExampleItem[] = (() => {
         },
         {
           key: 'HGVSc',
-          value: 'ALDH2:c.1510G>A',
-        },
-        {
-          key: 'HGVSc',
-          value: 'NM_000690:c.1510G>A',
+          value: ['ALDH2:c.1510G>A', 'NM_000690:c.1510G>A'],
         },
         {
           key: 'Chr:Position:Ref>Alt',
@@ -121,7 +113,7 @@ export const EXAMPLES: ExampleItem[] = (() => {
           key: 'Region',
           value: '12:111803962-111803962',
         },
-      {
+        {
           key: 'Disease',
           value: '"Alcohol sensitivity"',
         },

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchConstants.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchConstants.ts
@@ -1,15 +1,10 @@
 import { API_URL } from '../../../global';
+import type { ExampleItem } from './SimpleSearchTypes';
 
 /** SimpleSearchConstants - SimpleSearchView関連の定数定義 */
 
 /** グローバル変数の型宣言 */
 declare const TOGOVAR_FRONTEND_REFERENCE: 'GRCh37' | 'GRCh38' | string;
-
-/** 検索例のアイテム型 */
-export interface ExampleItem {
-  key: string;
-  value: string | string[];
-}
 
 /** 検索フィールド設定の型 */
 export interface SearchFieldConfig {

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchController.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchController.ts
@@ -4,7 +4,7 @@ import { CHROMOSOME_PATTERN } from './SimpleSearchConstants';
 import type {
   SimpleSearchHost,
   SuggestionItem,
-  ExampleItem,
+  ExampleSelectedDetail,
 } from './SimpleSearchTypes';
 
 /**
@@ -75,7 +75,7 @@ export class SimpleSearchController {
    * 例文選択時の処理
    * @param example - 選択された例文
    */
-  selectExample(example: ExampleItem): void {
+  selectExample(example: ExampleSelectedDetail): void {
     this.host._hideSuggestions = true;
     this.host._value = example.value;
     this.host._term = example.value;

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchEventHandlers.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchEventHandlers.ts
@@ -4,7 +4,7 @@ import type {
   SimpleSearchHost,
   SimpleSearchControllerInterface,
   SuggestionItem,
-  ExampleItem,
+  ExampleSelectedDetail,
 } from './SimpleSearchTypes';
 
 export class SimpleSearchEventHandlers {
@@ -31,7 +31,7 @@ export class SimpleSearchEventHandlers {
    * 例文選択イベントの処理
    * @param e - example-selected イベント
    */
-  handleExampleSelected = (e: CustomEvent<ExampleItem>): void => {
+  handleExampleSelected = (e: CustomEvent<ExampleSelectedDetail>): void => {
     this.controller.selectExample(e.detail);
   };
 

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
@@ -27,7 +27,7 @@ export default class SimpleSearchExamples extends LitElement {
     };
 
     this.dispatchEvent(
-      new CustomEvent('example-selected', {
+      new CustomEvent<ExampleSelectedDetail>('example-selected', {
         detail,
         bubbles: true,
         composed: true,
@@ -51,11 +51,12 @@ export default class SimpleSearchExamples extends LitElement {
               ${map(
                 values,
                 (value, index) =>
-                  html`${index > 0 ? ', ' : ''}<span
+                  html`${index > 0 ? ', ' : ''}<button
+                      type="button"
                       @click=${() => this.handleClick(example, value)}
                     >
                       ${value}
-                    </span>`
+                    </button>`
               )}
             </dd>
           </dl>`;

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
@@ -17,12 +17,16 @@ export default class SimpleSearchExamples extends LitElement {
 
   /**
    * 例文クリック時のイベントハンドラー
-   * @param example - クリックされた例文データ
-   * @param value - 検索に使う値
+   * @param e - クリックイベント
    */
-  private handleClick(example: ExampleItem, value: string): void {
+  private handleClick = (e: Event): void => {
+    const button = e.currentTarget as HTMLButtonElement;
+    const key = button.dataset.key;
+    const value = button.dataset.value;
+    if (!key || !value) return;
+
     const detail: ExampleSelectedDetail = {
-      key: example.key,
+      key,
       value,
     };
 
@@ -33,7 +37,7 @@ export default class SimpleSearchExamples extends LitElement {
         composed: true,
       })
     );
-  }
+  };
 
   private getValues(example: ExampleItem): string[] {
     return Array.isArray(example.value) ? example.value : [example.value];
@@ -53,7 +57,9 @@ export default class SimpleSearchExamples extends LitElement {
                 (value, index) =>
                   html`${index > 0 ? ', ' : ''}<button
                       type="button"
-                      @click=${() => this.handleClick(example, value)}
+                      data-key=${example.key}
+                      data-value=${value}
+                      @click=${this.handleClick}
                     >
                       ${value}
                     </button>`

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
@@ -8,6 +8,11 @@ import Styles from '../../../../stylesheets/object/component/simple-search-examp
 /** 例文データの型定義 */
 export interface ExampleItem {
   key: string;
+  value: string | string[];
+}
+
+interface ExampleSelectedDetail {
+  key: string;
   value: string;
 }
 
@@ -23,26 +28,48 @@ export default class SimpleSearchExamples extends LitElement {
   /**
    * 例文クリック時のイベントハンドラー
    * @param example - クリックされた例文データ
+   * @param value - 検索に使う値
    */
-  private handleClick(example: ExampleItem): void {
+  private handleClick(example: ExampleItem, value: string): void {
+    const detail: ExampleSelectedDetail = {
+      key: example.key,
+      value,
+    };
+
     this.dispatchEvent(
       new CustomEvent('example-selected', {
-        detail: example,
+        detail,
         bubbles: true,
         composed: true,
       })
     );
   }
 
+  private getValues(example: ExampleItem): string[] {
+    return Array.isArray(example.value) ? example.value : [example.value];
+  }
+
   render(): TemplateResult {
     return html`
       ${map(
         this.examples,
-        (example: ExampleItem) =>
-          html`<dl @click=${() => this.handleClick(example)}>
+        (example: ExampleItem) => {
+          const values = this.getValues(example);
+          return html`<dl>
             <dt>${example.key}</dt>
-            <dd>${example.value}</dd>
-          </dl>`
+            <dd>
+              ${map(
+                values,
+                (value, index) =>
+                  html`${index > 0 ? ', ' : ''}<span
+                      @click=${() => this.handleClick(example, value)}
+                    >
+                      ${value}
+                    </span>`
+              )}
+            </dd>
+          </dl>`;
+        }
       )}
     `;
   }

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts
@@ -4,17 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { map } from 'lit/directives/map.js';
 
 import Styles from '../../../../stylesheets/object/component/simple-search-examples.scss';
-
-/** 例文データの型定義 */
-export interface ExampleItem {
-  key: string;
-  value: string | string[];
-}
-
-interface ExampleSelectedDetail {
-  key: string;
-  value: string;
-}
+import type { ExampleItem, ExampleSelectedDetail } from './SimpleSearchTypes';
 
 /** SimpleSearchExamples - Simple検索用の例表示コンポーネント */
 @customElement('simple-search-examples')

--- a/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchTypes.ts
+++ b/app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchTypes.ts
@@ -28,16 +28,22 @@ export interface SuggestionItem {
 
 /** 例文アイテムの型 */
 export interface ExampleItem {
-  /** 例文の値 */
+  /** 例文の分類ラベル */
+  key: string;
+  /** 表示する例文の値 */
+  value: string | string[];
+}
+
+/** example-selected イベントで検索処理へ渡す値 */
+export interface ExampleSelectedDetail {
+  key: string;
   value: string;
-  /** 例文のラベル（オプション） */
-  label?: string;
 }
 
 /** Controller インターフェース */
 export interface SimpleSearchControllerInterface {
   selectSuggestion(suggestion: SuggestionItem): void;
-  selectExample(example: ExampleItem): void;
+  selectExample(example: ExampleSelectedDetail): void;
   updateTerm(term: string): void;
   executeCurrentSearch(): void;
   executeButtonSearch(): void;

--- a/app/frontend/stylesheets/object/component/simple-search-examples.scss
+++ b/app/frontend/stylesheets/object/component/simple-search-examples.scss
@@ -39,9 +39,7 @@ dl {
       color: inherit;
       font: inherit;
       cursor: pointer;
-      transition:
-        background-color $GUI_DURATION,
-        box-shadow $GUI_DURATION;
+      transition: background-color $GUI_DURATION;
 
       &:hover,
       &:focus-visible {

--- a/app/frontend/stylesheets/object/component/simple-search-examples.scss
+++ b/app/frontend/stylesheets/object/component/simple-search-examples.scss
@@ -30,16 +30,21 @@ dl {
   > dd {
     margin-inline-start: -0.2rem;
 
-    > span {
+    > button {
       display: inline-block;
       padding: 0 0.25rem;
+      border: 0;
       border-radius: 8px;
+      background: transparent;
+      color: inherit;
+      font: inherit;
       cursor: pointer;
       transition:
         background-color $GUI_DURATION,
         box-shadow $GUI_DURATION;
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         background-color: $COLOR_KEY_DARK2;
       }
     }

--- a/app/frontend/stylesheets/object/component/simple-search-examples.scss
+++ b/app/frontend/stylesheets/object/component/simple-search-examples.scss
@@ -1,7 +1,7 @@
 @use '../../foundation/_variables.scss' as *;
 :host {
   display: flex;
-  gap: 0.2em;
+  gap: 0.5rem;
   flex-wrap: wrap;
   align-items: center;
   height: fit-content;
@@ -11,14 +11,8 @@ dl {
   font-size: 12px;
   line-height: 16px;
   margin-bottom: 0;
-  padding: 0 0.5em;
   display: inline-block;
   margin-block-start: 0;
-  border-radius: 8px;
-  cursor: pointer;
-  transition:
-    background-color $GUI_DURATION,
-    box-shadow $GUI_DURATION;
   > dt,
   > dd {
     display: inline-block;
@@ -34,9 +28,20 @@ dl {
     }
   }
   > dd {
-    margin-inline-start: 0.2em;
-  }
-  &:hover {
-    background-color: $COLOR_KEY_DARK2;
+    margin-inline-start: -0.2rem;
+
+    > span {
+      display: inline-block;
+      padding: 0 0.25rem;
+      border-radius: 8px;
+      cursor: pointer;
+      transition:
+        background-color $GUI_DURATION,
+        box-shadow $GUI_DURATION;
+
+      &:hover {
+        background-color: $COLOR_KEY_DARK2;
+      }
+    }
   }
 }


### PR DESCRIPTION
[#324](https://github.com/togovar/meeting/issues/324)
Simple searchの検索例のUIを変更しました。

This pull request updates the example search functionality to support multiple example values for a single key and improves the UI for displaying and interacting with these examples. The main changes include updating the data model to allow arrays of values, adjusting the event handling to distinguish which value was selected, and enhancing the UI for better usability.

### Feature and Data Model Enhancements

* The `ExampleItem` interface now supports `value` as either a string or an array of strings, allowing each example key to have multiple associated values. (`app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchConstants.ts`, `app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts`) [[1]](diffhunk://#diff-15e60d655c753557557e63f7bb47326cfc6e34c07820151aa77243422c803305L11-R11) [[2]](diffhunk://#diff-48b5a6814d0a950b398b90fe1b56f823f2fa136ae0cbf83a5bc5e8366bcc3a61R10-R14)
* The example data (`EXAMPLES`) is updated so that keys with multiple values (like `'HGVSc'`) are represented as arrays instead of repeated entries. (`app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchConstants.ts`) [[1]](diffhunk://#diff-15e60d655c753557557e63f7bb47326cfc6e34c07820151aa77243422c803305L55-R55) [[2]](diffhunk://#diff-15e60d655c753557557e63f7bb47326cfc6e34c07820151aa77243422c803305L102-R98)

### UI and Event Handling Improvements

* The example rendering logic now displays each value as a separate clickable element, and the event handler dispatches which specific value was selected, not just the key. (`app/frontend/src/components/SearchField/SimpleSearch/SimpleSearchExamples.ts`)
* The styling is updated to visually separate each value, provide hover effects, and improve spacing for better user interaction. (`app/frontend/stylesheets/object/component/simple-search-examples.scss`) [[1]](diffhunk://#diff-a8bc0fa6dea1ecb9a32ec144d7411c6caa0e1f9fbe9ce58e489d40e60fec6634L4-R4) [[2]](diffhunk://#diff-a8bc0fa6dea1ecb9a32ec144d7411c6caa0e1f9fbe9ce58e489d40e60fec6634L14-L21) [[3]](diffhunk://#diff-a8bc0fa6dea1ecb9a32ec144d7411c6caa0e1f9fbe9ce58e489d40e60fec6634L37-R47)