### PR TITLE
fix frequency-count-value-view style

### DIFF
--- a/app/frontend/stylesheets/foundation/_variables.scss
+++ b/app/frontend/stylesheets/foundation/_variables.scss
@@ -187,6 +187,7 @@ $SHADOW_DEPTH1: 0 1px 1px rgba(black, 0.3);
   --height-inline: 18px;
   --height-advanced-search-condition-values-container: 24px;
   --height-advanced-search-condition-value: 18px;
+  --left-advanced-search-condition-graph: 142px;
 
   // z-index
   --z-index-base: 10000;

--- a/app/frontend/stylesheets/object/component/condition-item-value-view.scss
+++ b/app/frontend/stylesheets/object/component/condition-item-value-view.scss
@@ -26,6 +26,12 @@
 :host([data-condition-type='genotype']) {
   display: block;
   position: relative;
+  frequency-count-value-view {
+    position: absolute;
+    top: 50%;
+    left: 142px;
+    transform: translateY(-50%);
+  }
   .inner {
     min-width: 50px;
     &::before {

--- a/app/frontend/stylesheets/object/component/condition-item-value-view.scss
+++ b/app/frontend/stylesheets/object/component/condition-item-value-view.scss
@@ -26,6 +26,7 @@
 :host([data-condition-type='genotype']) {
   display: block;
   position: relative;
+  // dataset/genotypeは同じfrequency-count-value-viewを使うため、bar開始位置も揃える。
   frequency-count-value-view {
     position: absolute;
     top: 50%;

--- a/app/frontend/stylesheets/object/component/condition-item-value-view.scss
+++ b/app/frontend/stylesheets/object/component/condition-item-value-view.scss
@@ -30,7 +30,7 @@
   frequency-count-value-view {
     position: absolute;
     top: 50%;
-    left: 142px;
+    left: var(--left-advanced-search-condition-graph);
     transform: translateY(-50%);
   }
   .inner {

--- a/app/frontend/stylesheets/object/component/prediction-value-view.scss
+++ b/app/frontend/stylesheets/object/component/prediction-value-view.scss
@@ -3,7 +3,7 @@
 :host {
   position: absolute;
   top: 0;
-  left: 142px;
+  left: var(--left-advanced-search-condition-graph);
   display: flex;
   align-items: center;
   white-space: nowrap;


### PR DESCRIPTION
dataset / genotype の frequency-count bar の開始位置を Pathogenicity prediction のbar位置に揃える。
<img width="1461" height="193" alt="image" src="https://github.com/user-attachments/assets/186b8aaf-38c6-4f89-81ee-6428fdf6acc6" />


This pull request makes a targeted UI improvement to the `condition-item-value-view` component. Specifically, it updates the styling for the `frequency-count-value-view` element when the condition type is set to `genotype`, ensuring it is positioned absolutely and vertically centered within its parent.

- UI/Styling adjustment:
  * Added CSS rules to position `frequency-count-value-view` absolutely, aligning it vertically centered and 142px from the left, within the `:host([data-condition-type='genotype'])` context in `condition-item-value-view.scss`.