### PR TITLE
Fix/results

### DIFF
--- a/app/frontend/src/components/Results/ResultsColumnAutoSizer.ts
+++ b/app/frontend/src/components/Results/ResultsColumnAutoSizer.ts
@@ -14,47 +14,32 @@ const AUTO_SIZE_EXTRA_WIDTH = 4;
  * DOMの実測値を使ってレンダリング後に動的に確定する。
  */
 export class ResultsColumnAutoSizer {
-  /** autoSize の対象行を含む tbody 要素 */
-  private _tbody: HTMLElement;
+  private tbody: HTMLElement;
   /** 同じ検索結果に対する二重実行を防ぐための署名キャッシュ */
-  private _autoSizedResultSignature = '';
+  private autoSizedResultSignature = '';
   /** ユーザーが手動でリサイズした列は自動調整から除外するためにIDを保持する */
-  private _resizedColumnIds = new Set<string>();
-  private _boundAutoSizeResultColumns: (_event: Event) => void;
-  private _boundResetAutoSizeState: (
-    _version: number
-  ) => void;
+  private resizedColumnIds = new Set<string>();
+  private boundAutoSizeResultColumns: (_event: Event) => void;
+  private boundResetAutoSizeState: (_version: number) => void;
   /** getBoundingClientRect はDOMに配置されていないと0を返すため、非表示テーブルで計測する */
-  private _measuringTable: HTMLTableElement | null = null;
-  private _measuringRow: HTMLTableRowElement | null = null;
+  private measuringTable: HTMLTableElement | null = null;
+  private measuringRow: HTMLTableRowElement | null = null;
 
   constructor(tbody: HTMLElement) {
-    this._tbody = tbody;
-    this._boundAutoSizeResultColumns = this.autoSizeResultColumns.bind(this);
-    this._boundResetAutoSizeState = () => this.resetAutoSizeState();
-    window.addEventListener(
-      'togovar:results-rendered',
-      this._boundAutoSizeResultColumns
-    );
-    storeManager.subscribe(
-      'resultsResetVersion',
-      this._boundResetAutoSizeState
-    );
+    this.tbody = tbody;
+    this.boundAutoSizeResultColumns = this.autoSizeResultColumns.bind(this);
+    this.boundResetAutoSizeState = () => this.resetAutoSizeState();
+    window.addEventListener('togovar:results-rendered', this.boundAutoSizeResultColumns);
+    storeManager.subscribe('resultsResetVersion', this.boundResetAutoSizeState);
   }
 
   /** イベントリスナーと計測用DOMを同時に破棄し、メモリリークを防ぐ。 */
   destroy(): void {
-    window.removeEventListener(
-      'togovar:results-rendered',
-      this._boundAutoSizeResultColumns
-    );
-    storeManager.unsubscribe(
-      'resultsResetVersion',
-      this._boundResetAutoSizeState
-    );
-    this._measuringTable?.remove();
-    this._measuringTable = null;
-    this._measuringRow = null;
+    window.removeEventListener('togovar:results-rendered', this.boundAutoSizeResultColumns);
+    storeManager.unsubscribe('resultsResetVersion', this.boundResetAutoSizeState);
+    this.measuringTable?.remove();
+    this.measuringTable = null;
+    this.measuringRow = null;
   }
 
   /**
@@ -67,7 +52,7 @@ export class ResultsColumnAutoSizer {
     const column = columns.find((c) => c.id === columnId);
     if (!column || !column.isUsed || usesInitialColumnWidth(columnId)) return;
 
-    const contentWidth = this._measureColumnContentWidth(columnId);
+    const contentWidth = this.measureColumnContentWidth(columnId);
     const width =
       contentWidth <= 0
         ? getMinColumnWidth()
@@ -81,33 +66,30 @@ export class ResultsColumnAutoSizer {
 
   /** 列リセット時に署名とリサイズ記録を同時にクリアして次回自動調整を有効にする。 */
   resetAutoSizeState(): void {
-    this._autoSizedResultSignature = '';
-    this._resizedColumnIds.clear();
+    this.autoSizedResultSignature = '';
+    this.resizedColumnIds.clear();
   }
 
   /** 検索条件変更だけで結果が変わっていない場合に再調整を強制するための署名クリア。 */
   resetSignature(): void {
-    this._autoSizedResultSignature = '';
+    this.autoSizedResultSignature = '';
   }
 
   /** ユーザーが手動でリサイズした列を記録し、自動調整による上書きを防ぐ。 */
   markColumnResized(columnId: string): void {
-    this._resizedColumnIds.add(columnId);
+    this.resizedColumnIds.add(columnId);
   }
 
   /**
    * 全列幅を初期値に戻し、次回の自動調整を有効にする。
-   * ユーザーのリサイズ操作もリセットされるため、resetAutoSizeState も呼ぶ。
    */
   resetColumnWidths(): void {
     this.resetAutoSizeState();
 
-    const columns = normalizeColumnConfigs(storeManager.getData('columns')).map(
-      (column) => ({
-        ...column,
-        width: getInitialColumnWidth(column.id),
-      })
-    );
+    const columns = normalizeColumnConfigs(storeManager.getData('columns')).map((column) => ({
+      ...column,
+      width: getInitialColumnWidth(column.id),
+    }));
 
     storeManager.setData('columns', columns);
   }
@@ -117,10 +99,7 @@ export class ResultsColumnAutoSizer {
    * ページ送りや再描画ごとに呼ばれるが、署名が同じなら処理をスキップして無駄な再計測を防ぐ。
    */
   autoSizeResultColumns(event?: Event): void {
-    if (
-      event instanceof CustomEvent &&
-      event.detail?.reason !== 'searchResults'
-    ) {
+    if (event instanceof CustomEvent && event.detail?.reason !== 'searchResults') {
       return;
     }
 
@@ -128,25 +107,18 @@ export class ResultsColumnAutoSizer {
       return;
     }
 
-    const resultSignature = this._getResultSignature();
-    if (
-      !resultSignature ||
-      resultSignature === this._autoSizedResultSignature
-    ) {
+    const resultSignature = this.getResultSignature();
+    if (!resultSignature || resultSignature === this.autoSizedResultSignature) {
       return;
     }
 
     const columns = normalizeColumnConfigs(storeManager.getData('columns'));
     const nextColumns = columns.map((column) => {
-      if (
-        !column.isUsed ||
-        usesInitialColumnWidth(column.id) ||
-        this._resizedColumnIds.has(column.id)
-      ) {
+      if (!column.isUsed || usesInitialColumnWidth(column.id) || this.resizedColumnIds.has(column.id)) {
         return column;
       }
 
-      const contentWidth = this._measureColumnContentWidth(column.id);
+      const contentWidth = this.measureColumnContentWidth(column.id);
       if (contentWidth <= 0) {
         return { ...column, width: getMinColumnWidth() };
       }
@@ -154,14 +126,14 @@ export class ResultsColumnAutoSizer {
       return { ...column, width: Math.max(getMinColumnWidth(), contentWidth) };
     });
 
-    this._autoSizedResultSignature = resultSignature;
+    this.autoSizedResultSignature = resultSignature;
     storeManager.setData('columns', nextColumns);
   }
 
   /**
    * 結果セット全体をシリアライズすると重いため、先頭IDと総件数の組み合わせで差分を検出する。
    */
-  private _getResultSignature(): string {
+  private getResultSignature(): string {
     const results = storeManager.getData('searchResults');
     const numberOfRecords = storeManager.getData('numberOfRecords');
 
@@ -175,14 +147,13 @@ export class ResultsColumnAutoSizer {
 
   /**
    * 指定列のセル群から最大コンテンツ幅を実測して返す。
-   * 計測対象セルの抽出と幅計算を1パスにまとめ、_getMeasureTarget の二重呼び出しを避ける。
    */
-  private _measureColumnContentWidth(columnId: string): number {
+  private measureColumnContentWidth(columnId: string): number {
     const cellsWithContent = Array.from(
-      this._tbody.querySelectorAll<HTMLTableCellElement>(`td.${columnId}`)
+      this.tbody.querySelectorAll<HTMLTableCellElement>(`td.${columnId}`)
     ).flatMap((cell) => {
       if (cell.offsetParent === null) return [];
-      const content = this._getMeasureTarget(cell, columnId);
+      const content = this.getMeasureTarget(cell, columnId);
       if (!content?.textContent?.trim()) return [];
       return [{ cell, content }];
     });
@@ -197,7 +168,7 @@ export class ResultsColumnAutoSizer {
             parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
 
           return (
-            this._measureContentBoxWidth(cell, content) +
+            this.measureContentBoxWidth(cell, content) +
             horizontalPadding +
             AUTO_SIZE_EXTRA_WIDTH
           );
@@ -209,41 +180,32 @@ export class ResultsColumnAutoSizer {
   /**
    * コンテンツの実際の描画幅を複数手法で取得する。
    * 制約なし計測が取れればそれを優先し、取れない場合は RangeAPI と scrollWidth で補完する。
-   * Range はインラインテキストに有効で、scrollWidth はオーバーフロー要素に有効なためどちらも試す。
    */
-  private _measureContentBoxWidth(
+  private measureContentBoxWidth(
     cell: HTMLTableCellElement,
     content: HTMLElement
   ): number {
-    const unconstrainedWidth = this._measureUnconstrainedContentWidth(
-      cell,
-      content
-    );
+    const unconstrainedWidth = this.measureUnconstrainedContentWidth(cell, content);
     if (unconstrainedWidth > 0) {
       return unconstrainedWidth;
     }
 
-    const rangeWidth = this._measureRangeWidth(cell, content);
+    const rangeWidth = this.measureRangeWidth(cell, content);
     if (content === cell) {
       return rangeWidth;
     }
 
-    return Math.max(
-      rangeWidth,
-      content.scrollWidth,
-      content.getBoundingClientRect().width
-    );
+    return Math.max(rangeWidth, content.scrollWidth, content.getBoundingClientRect().width);
   }
 
   /**
    * セルを非表示の計測用テーブルにクローンして幅の制約を外し、コンテンツ本来の幅を得る。
-   * 計測後すぐ子要素を除去して次の計測に再利用できるようにする。
    */
-  private _measureUnconstrainedContentWidth(
+  private measureUnconstrainedContentWidth(
     cell: HTMLTableCellElement,
     content: HTMLElement
   ): number {
-    const measuringRow = this._getMeasuringRow();
+    const measuringRow = this.getMeasuringRow();
     const measuringCell = cell.cloneNode(false) as HTMLTableCellElement;
 
     measuringCell.style.width = 'auto';
@@ -255,10 +217,7 @@ export class ResultsColumnAutoSizer {
 
     if (content === cell) {
       Array.from(cell.childNodes).forEach((node) => {
-        if (
-          node instanceof HTMLElement &&
-          node.classList.contains('resize-bar')
-        ) {
+        if (node instanceof HTMLElement && node.classList.contains('resize-bar')) {
           return;
         }
         measuringCell.appendChild(node.cloneNode(true));
@@ -281,11 +240,10 @@ export class ResultsColumnAutoSizer {
 
   /**
    * 計測用テーブルをキャッシュして再利用するため、DOMへの追加は初回のみにする。
-   * テーブルがDOMから切り離されていた場合も再生成して正確なレイアウトを保証する。
    */
-  private _getMeasuringRow(): HTMLTableRowElement {
-    if (this._measuringRow && this._measuringTable?.isConnected) {
-      return this._measuringRow;
+  private getMeasuringRow(): HTMLTableRowElement {
+    if (this.measuringRow && this.measuringTable?.isConnected) {
+      return this.measuringRow;
     }
 
     const table = document.createElement('table');
@@ -305,28 +263,21 @@ export class ResultsColumnAutoSizer {
     table.appendChild(tbody);
     document.body.appendChild(table);
 
-    this._measuringTable = table;
-    this._measuringRow = row;
+    this.measuringTable = table;
+    this.measuringRow = row;
 
     return row;
   }
 
   /**
    * Range API でコンテンツノードを囲んで幅を取得する。
-   * getBoundingClientRect より精度が高いケースがあるため、フォールバック計測に使う。
    */
-  private _measureRangeWidth(
-    cell: HTMLTableCellElement,
-    content: HTMLElement
-  ): number {
+  private measureRangeWidth(cell: HTMLTableCellElement, content: HTMLElement): number {
     const range = document.createRange();
 
     if (content === cell) {
       const contentNodes = Array.from(cell.childNodes).filter(
-        (node) =>
-          !(
-            node instanceof HTMLElement && node.classList.contains('resize-bar')
-          )
+        (node) => !(node instanceof HTMLElement && node.classList.contains('resize-bar'))
       );
 
       if (contentNodes.length === 0) return 0;
@@ -342,12 +293,8 @@ export class ResultsColumnAutoSizer {
 
   /**
    * 列IDによってセル内の計測対象サブ要素を切り替える。
-   * セル全体ではなくラベル要素だけを計測することで、パディングや装飾の過大評価を防ぐ。
    */
-  private _getMeasureTarget(
-    cell: HTMLTableCellElement,
-    columnId: string
-  ): HTMLElement {
+  private getMeasureTarget(cell: HTMLTableCellElement, columnId: string): HTMLElement {
     const selectorByColumn: Record<string, string> = {
       ref_alt: '.ref-alt',
       position: '.chromosome-position',

--- a/app/frontend/src/components/Results/ResultsColumnResizeController.ts
+++ b/app/frontend/src/components/Results/ResultsColumnResizeController.ts
@@ -39,48 +39,40 @@ type ResultsColumnResizeControllerOptions = {
  * hover 表示、列幅リセットを担当する。確定した列幅は storeManager に保存する。
  */
 export class ResultsColumnResizeController {
-  /** 結果テーブルのヘッダー */
-  private _thead: HTMLElement;
-  /** 結果テーブルのボディ */
-  private _tbody: HTMLElement;
-  /** 結果テーブルを囲むスクロールコンテナ */
-  private _tablecontainer: HTMLElement;
-  /** 自動列幅調整の状態管理 */
-  private _autoSizer: ResultsColumnAutoSizer;
-  /** ドラッグ中の列幅を画面へ即時反映するコールバック */
-  private _previewColumns: (_columns: ColumnConfig[]) => void;
-  /** リサイズ対象列の境界線を表示するための動的 stylesheet */
-  private _columnBorderStylesheet!: HTMLStyleElement;
-  /** 現在のドラッグリサイズ状態。リサイズ中でなければ null */
-  private _resizeState: ColumnResizeState | null = null;
-  /** ドラッグが発生したことを示すフラグ。pointerup 後の click を一度だけ抑制するために使う */
-  private _wasDragging = false;
-  /** 最後に観測したポインターX座標。drag 終了後の hover 判定で使う */
-  private _lastPointerX = 0;
-  /** 最後に観測したポインターY座標。drag 終了後の hover 判定で使う */
-  private _lastPointerY = 0;
-  private _boundColumnResizeStart: (_e: PointerEvent) => void;
-  private _boundColumnResizeMove: (_e: PointerEvent) => void;
-  private _boundColumnResizeEnd: () => void;
-  private _boundAutoSizeColumnOnDblClick: (_e: MouseEvent) => void;
-  private _boundStopClickOnResizeBar: (_e: MouseEvent) => void;
-  private _boundResizeHoverOver: (_e: MouseEvent) => void;
-  private _boundResizeHoverLeave: () => void;
+  private thead: HTMLElement;
+  private tbody: HTMLElement;
+  private tablecontainer: HTMLElement;
+  private autoSizer: ResultsColumnAutoSizer;
+  private previewColumns: (_columns: ColumnConfig[]) => void;
+  private columnBorderStylesheet!: HTMLStyleElement;
+  private resizeState: ColumnResizeState | null = null;
+  /** pointerup 後の click を一度だけ抑制するフラグ */
+  private wasDragging = false;
+  /** drag 終了後の hover 判定で使う最後のポインター座標 */
+  private lastPointerX = 0;
+  private lastPointerY = 0;
+  private boundColumnResizeStart: (_e: PointerEvent) => void;
+  private boundColumnResizeMove: (_e: PointerEvent) => void;
+  private boundColumnResizeEnd: () => void;
+  private boundAutoSizeColumnOnDblClick: (_e: MouseEvent) => void;
+  private boundStopClickOnResizeBar: (_e: MouseEvent) => void;
+  private boundResizeHoverOver: (_e: MouseEvent) => void;
+  private boundResizeHoverLeave: () => void;
 
   constructor(options: ResultsColumnResizeControllerOptions) {
-    this._thead = options.thead;
-    this._tbody = options.tbody;
-    this._tablecontainer = options.tablecontainer;
-    this._autoSizer = options.autoSizer;
-    this._previewColumns = options.previewColumns;
+    this.thead = options.thead;
+    this.tbody = options.tbody;
+    this.tablecontainer = options.tablecontainer;
+    this.autoSizer = options.autoSizer;
+    this.previewColumns = options.previewColumns;
 
-    this._boundColumnResizeStart = this._startColumnResize.bind(this);
-    this._boundColumnResizeMove = this._moveColumnResize.bind(this);
-    this._boundColumnResizeEnd = this._endColumnResize.bind(this);
-    this._boundAutoSizeColumnOnDblClick = this._onResizeBarDblClick.bind(this);
-    this._boundStopClickOnResizeBar = (e: MouseEvent) => {
-      if (this._wasDragging) {
-        this._wasDragging = false;
+    this.boundColumnResizeStart = this.startColumnResize.bind(this);
+    this.boundColumnResizeMove = this.moveColumnResize.bind(this);
+    this.boundColumnResizeEnd = this.endColumnResize.bind(this);
+    this.boundAutoSizeColumnOnDblClick = this.onResizeBarDblClick.bind(this);
+    this.boundStopClickOnResizeBar = (e: MouseEvent) => {
+      if (this.wasDragging) {
+        this.wasDragging = false;
         e.stopPropagation();
         return;
       }
@@ -88,80 +80,59 @@ export class ResultsColumnResizeController {
         e.stopPropagation();
       }
     };
-    this._boundResizeHoverOver = this._onResizeHoverOver.bind(this);
-    this._boundResizeHoverLeave = this._onResizeHoverLeave.bind(this);
+    this.boundResizeHoverOver = this.onResizeHoverOver.bind(this);
+    this.boundResizeHoverLeave = this.onResizeHoverLeave.bind(this);
 
-    this._attachEventHandlers();
-    this._createColumnBorderStyles();
+    this.attachEventHandlers();
+    this.createColumnBorderStyles();
   }
 
   /**
    * 登録したイベントリスナーと動的 stylesheet を破棄する。
    */
   destroy(): void {
-    this._thead.removeEventListener(
-      'pointerdown',
-      this._boundColumnResizeStart
-    );
-    this._thead.removeEventListener('dblclick', this._boundAutoSizeColumnOnDblClick);
-    this._tbody.removeEventListener('dblclick', this._boundAutoSizeColumnOnDblClick);
-    this._tbody.removeEventListener('click', this._boundStopClickOnResizeBar, true);
-    document.removeEventListener('pointermove', this._boundColumnResizeMove);
-    document.removeEventListener('pointerup', this._boundColumnResizeEnd);
-    document.removeEventListener('pointercancel', this._boundColumnResizeEnd);
-    this._tbody.removeEventListener(
-      'pointerdown',
-      this._boundColumnResizeStart
-    );
-    this._tablecontainer.removeEventListener(
-      'mouseover',
-      this._boundResizeHoverOver
-    );
-    this._tablecontainer.removeEventListener(
-      'mouseleave',
-      this._boundResizeHoverLeave
-    );
+    this.thead.removeEventListener('pointerdown', this.boundColumnResizeStart);
+    this.thead.removeEventListener('dblclick', this.boundAutoSizeColumnOnDblClick);
+    this.tbody.removeEventListener('dblclick', this.boundAutoSizeColumnOnDblClick);
+    this.tbody.removeEventListener('click', this.boundStopClickOnResizeBar, true);
+    document.removeEventListener('pointermove', this.boundColumnResizeMove);
+    document.removeEventListener('pointerup', this.boundColumnResizeEnd);
+    document.removeEventListener('pointercancel', this.boundColumnResizeEnd);
+    this.tbody.removeEventListener('pointerdown', this.boundColumnResizeStart);
+    this.tablecontainer.removeEventListener('mouseover', this.boundResizeHoverOver);
+    this.tablecontainer.removeEventListener('mouseleave', this.boundResizeHoverLeave);
 
-    if (this._columnBorderStylesheet) {
-      this._columnBorderStylesheet.remove();
+    if (this.columnBorderStylesheet) {
+      this.columnBorderStylesheet.remove();
     }
 
-    this._resizeState = null;
+    this.resizeState = null;
     delete document.body.dataset.columnResizing;
-    delete this._tablecontainer.dataset.resizeHover;
+    delete this.tablecontainer.dataset.resizeHover;
   }
 
   /**
    * 列リサイズに必要な pointer / hover / reset イベントを登録する。
    */
-  private _attachEventHandlers(): void {
-    this._thead.addEventListener('pointerdown', this._boundColumnResizeStart);
-    this._tbody.addEventListener('pointerdown', this._boundColumnResizeStart);
-    this._thead.addEventListener('dblclick', this._boundAutoSizeColumnOnDblClick);
-    this._tbody.addEventListener('dblclick', this._boundAutoSizeColumnOnDblClick);
+  private attachEventHandlers(): void {
+    this.thead.addEventListener('pointerdown', this.boundColumnResizeStart);
+    this.tbody.addEventListener('pointerdown', this.boundColumnResizeStart);
+    this.thead.addEventListener('dblclick', this.boundAutoSizeColumnOnDblClick);
+    this.tbody.addEventListener('dblclick', this.boundAutoSizeColumnOnDblClick);
     // キャプチャフェーズで登録することで、tr のサイドバーハンドラーより先に伝播を止める。
-    // バブリング登録だと tbody に届いた時点でサイドバー側がすでに実行済みになる。
-    this._tbody.addEventListener('click', this._boundStopClickOnResizeBar, true);
-    document.addEventListener('pointermove', this._boundColumnResizeMove);
-    document.addEventListener('pointerup', this._boundColumnResizeEnd);
-    document.addEventListener('pointercancel', this._boundColumnResizeEnd);
-    this._tablecontainer.addEventListener(
-      'mouseover',
-      this._boundResizeHoverOver
-    );
-    this._tablecontainer.addEventListener(
-      'mouseleave',
-      this._boundResizeHoverLeave
-    );
+    this.tbody.addEventListener('click', this.boundStopClickOnResizeBar, true);
+    document.addEventListener('pointermove', this.boundColumnResizeMove);
+    document.addEventListener('pointerup', this.boundColumnResizeEnd);
+    document.addEventListener('pointercancel', this.boundColumnResizeEnd);
+    this.tablecontainer.addEventListener('mouseover', this.boundResizeHoverOver);
+    this.tablecontainer.addEventListener('mouseleave', this.boundResizeHoverLeave);
   }
 
   /**
    * resize-bar を掴んだときにドラッグ状態を開始する。
    */
-  private _startColumnResize(e: PointerEvent): void {
-    const resizeBar = (e.target as HTMLElement).closest<HTMLElement>(
-      '.resize-bar'
-    );
+  private startColumnResize(e: PointerEvent): void {
+    const resizeBar = (e.target as HTMLElement).closest<HTMLElement>('.resize-bar');
     if (!resizeBar) return;
 
     const cell = resizeBar.closest<HTMLTableCellElement>('th, td');
@@ -173,70 +144,63 @@ export class ResultsColumnResizeController {
     e.stopPropagation();
 
     // ユーザーが明示的に幅変更した列は、自動列幅調整の対象から外す。
-    this._autoSizer.markColumnResized(columnId);
+    this.autoSizer.markColumnResized(columnId);
 
     const columns = normalizeColumnConfigs(storeManager.getData('columns'));
     const column = columns.find((item) => item.id === columnId);
-    const startWidth =
-      column?.width || Math.round(cell.getBoundingClientRect().width);
+    const startWidth = column?.width || Math.round(cell.getBoundingClientRect().width);
 
-    this._resizeState = {
+    this.resizeState = {
       columnId,
       startX: e.clientX,
       startWidth,
       nextColumns: columns,
     };
-    this._lastPointerX = e.clientX;
-    this._lastPointerY = e.clientY;
-    // CSS 側でドラッグ中の境界線表示を切り替えるためのフラグ。
+    this.lastPointerX = e.clientX;
+    this.lastPointerY = e.clientY;
     document.body.dataset.columnResizing = 'true';
-    this._tablecontainer.dataset.resizeHover = columnId;
+    this.tablecontainer.dataset.resizeHover = columnId;
   }
 
   /**
    * ドラッグ中の移動量から列幅を計算し、画面へ一時反映する。
    */
-  private _moveColumnResize(e: PointerEvent): void {
-    if (!this._resizeState) return;
+  private moveColumnResize(e: PointerEvent): void {
+    if (!this.resizeState) return;
 
     e.preventDefault();
-    this._wasDragging = true;
-    this._lastPointerX = e.clientX;
-    this._lastPointerY = e.clientY;
+    this.wasDragging = true;
+    this.lastPointerX = e.clientX;
+    this.lastPointerY = e.clientY;
 
-    const { columnId, startX, startWidth } = this._resizeState;
+    const { columnId, startX, startWidth } = this.resizeState;
     const minWidth = getMinColumnWidth();
-    const nextWidth = Math.max(
-      minWidth,
-      Math.round(startWidth + e.clientX - startX)
-    );
+    const nextWidth = Math.max(minWidth, Math.round(startWidth + e.clientX - startX));
 
-    this._resizeState.nextColumns = this._resizeState.nextColumns.map(
-      (column) =>
-        column.id === columnId ? { ...column, width: nextWidth } : column
+    this.resizeState.nextColumns = this.resizeState.nextColumns.map((column) =>
+      column.id === columnId ? { ...column, width: nextWidth } : column
     );
-    this._previewColumns(this._resizeState.nextColumns);
+    this.previewColumns(this.resizeState.nextColumns);
   }
 
   /**
    * ドラッグを終了し、確定した列幅を store に保存する。
    */
-  private _endColumnResize(): void {
-    if (!this._resizeState) return;
+  private endColumnResize(): void {
+    if (!this.resizeState) return;
 
-    storeManager.setData('columns', this._resizeState.nextColumns);
-    this._resizeState = null;
+    storeManager.setData('columns', this.resizeState.nextColumns);
+    this.resizeState = null;
     delete document.body.dataset.columnResizing;
 
-    const x = this._lastPointerX;
-    const y = this._lastPointerY;
+    const x = this.lastPointerX;
+    const y = this.lastPointerY;
     // pointerup と同タスクの click が処理された後に実行されるため、
-    // click が発火しなかった場合（テーブル外で離す等）のフラグ残留をここで解消する。
-    // click が発火した場合はキャプチャハンドラーが先にクリア済みなので no-op になる。
+    // click が発火しなかった場合のフラグ残留をここで解消する。
     requestAnimationFrame(() => {
-      this._wasDragging = false;
+      this.wasDragging = false;
       if (!document.elementFromPoint(x, y)?.closest('.resize-bar')) {
-        delete this._tablecontainer.dataset.resizeHover;
+        delete this.tablecontainer.dataset.resizeHover;
       }
     });
   }
@@ -244,13 +208,11 @@ export class ResultsColumnResizeController {
   /**
    * resize-bar の hover 対象列を tablecontainer の data 属性へ反映する。
    */
-  private _onResizeHoverOver(e: MouseEvent): void {
-    if (this._resizeState) return;
-    const resizeBar = (e.target as HTMLElement).closest<HTMLElement>(
-      '.resize-bar'
-    );
+  private onResizeHoverOver(e: MouseEvent): void {
+    if (this.resizeState) return;
+    const resizeBar = (e.target as HTMLElement).closest<HTMLElement>('.resize-bar');
     if (!resizeBar) {
-      delete this._tablecontainer.dataset.resizeHover;
+      delete this.tablecontainer.dataset.resizeHover;
       return;
     }
     const cell = resizeBar.closest<HTMLElement>('th[data-column-id]');
@@ -260,30 +222,29 @@ export class ResultsColumnResizeController {
           // tbody 側の resize-bar では cellIndex から対応する th を引く。
           const td = resizeBar.closest<HTMLTableCellElement>('td');
           if (!td) return undefined;
-          return this._thead.querySelectorAll<HTMLElement>('th')[td.cellIndex]
-            ?.dataset.columnId;
+          return this.thead.querySelectorAll<HTMLElement>('th')[td.cellIndex]?.dataset.columnId;
         })();
     if (columnId) {
-      this._tablecontainer.dataset.resizeHover = columnId;
+      this.tablecontainer.dataset.resizeHover = columnId;
     }
   }
 
   /**
    * テーブル外へ出たら hover 表示を解除する。
    */
-  private _onResizeHoverLeave(): void {
-    if (!this._resizeState) {
-      delete this._tablecontainer.dataset.resizeHover;
+  private onResizeHoverLeave(): void {
+    if (!this.resizeState) {
+      delete this.tablecontainer.dataset.resizeHover;
     }
   }
 
   /**
    * リサイズ対象列の縦境界線を表示するための CSS ルールを生成する。
    */
-  private _createColumnBorderStyles(): void {
-    this._columnBorderStylesheet = document.createElement('style');
-    document.head.appendChild(this._columnBorderStylesheet);
-    const sheet = this._columnBorderStylesheet.sheet;
+  private createColumnBorderStyles(): void {
+    this.columnBorderStylesheet = document.createElement('style');
+    document.head.appendChild(this.columnBorderStylesheet);
+    const sheet = this.columnBorderStylesheet.sheet;
     if (!sheet) return;
     COLUMNS.forEach((column) => {
       const idleBase = `.tablecontainer .results-view`;
@@ -317,10 +278,8 @@ export class ResultsColumnResizeController {
 
   /**
    * resize-bar のダブルクリックで対象列をコンテンツ最大幅に自動調整する。
-   * tbody 側は行クリック（サイドバー表示）と競合するため、resize-bar 上の場合だけ
-   * stopPropagation と preventDefault で行選択イベントの伝播を止める。
    */
-  private _onResizeBarDblClick(e: MouseEvent): void {
+  private onResizeBarDblClick(e: MouseEvent): void {
     const resizeBar = (e.target as HTMLElement).closest<HTMLElement>('.resize-bar');
     if (!resizeBar) return;
 
@@ -331,6 +290,6 @@ export class ResultsColumnResizeController {
     const columnId = resizeBar.dataset.columnId || cell?.dataset.columnId;
     if (!columnId) return;
 
-    this._autoSizer.autoSizeColumn(columnId);
+    this.autoSizer.autoSizeColumn(columnId);
   }
 }

--- a/app/frontend/src/components/Results/ResultsColumnUpdater.ts
+++ b/app/frontend/src/components/Results/ResultsColumnUpdater.ts
@@ -501,7 +501,7 @@ export class ResultsColumnUpdater {
   static updateFunctionPrediction(
     element: HTMLDivElement | null,
     score: number | null | undefined,
-    classifyScore: (_score: number) => string
+    classifyScore: (score: number) => string
   ) {
     if (!element) return;
 
@@ -522,9 +522,9 @@ export class ResultsColumnUpdater {
    * @param score - AlphaMissenseスコア
    */
   static updateAlphaMissense(element: HTMLDivElement | null, score: number | null | undefined) {
-    this.updateFunctionPrediction(element, score, (_score) => {
-      if (_score < 0.34) return 'LB';
-      if (_score > 0.564) return 'LP';
+    this.updateFunctionPrediction(element, score, (s) => {
+      if (s < 0.34) return 'LB';
+      if (s > 0.564) return 'LP';
       return 'A';
     });
   }
@@ -536,9 +536,7 @@ export class ResultsColumnUpdater {
    * @param score - SIFTスコア
    */
   static updateSift(element: HTMLDivElement | null, score: number | null | undefined) {
-    this.updateFunctionPrediction(element, score, (_score) =>
-      _score >= 0.05 ? 'T' : 'D'
-    );
+    this.updateFunctionPrediction(element, score, (s) => (s >= 0.05 ? 'T' : 'D'));
   }
 
   /**
@@ -548,10 +546,10 @@ export class ResultsColumnUpdater {
    * @param score - PolyPhenスコア
    */
   static updatePolyphen(element: HTMLDivElement | null, score: number | null | undefined) {
-    this.updateFunctionPrediction(element, score, (_score) => {
-      if (_score > 0.908) return 'PROBD';
-      if (_score > 0.446) return 'POSSD';
-      if (_score >= 0) return 'B';
+    this.updateFunctionPrediction(element, score, (s) => {
+      if (s > 0.908) return 'PROBD';
+      if (s > 0.446) return 'POSSD';
+      if (s >= 0) return 'B';
       return 'U';
     });
   }

--- a/app/frontend/src/components/Results/ResultsColumnsDropdown.ts
+++ b/app/frontend/src/components/Results/ResultsColumnsDropdown.ts
@@ -31,33 +31,33 @@ const HOVER_CLOSE_DELAY_MS = 120;
  * - UI 操作が store.columns に自動反映
  */
 export class ResultsColumnsDropdown {
-  private readonly _root: HTMLElement;
-  private readonly _button: HTMLButtonElement;
-  private readonly _menu: HTMLElement;
-  private readonly _list: HTMLElement;
-  private _draggingElement: HTMLElement | null = null;
-  private _ghostElement: HTMLElement | null = null;
-  private _draggingCursorStyleEl: HTMLStyleElement | null = null;
-  private _clearPendingLongPress: (() => void) | null = null;
-  private _cleanupDragListeners: (() => void) | null = null;
-  private _suppressNextListClick = false;
-  private _hoverCloseTimer: number | null = null;
-  private readonly _eventAbortController = new AbortController();
-  private readonly _boundDocumentClick: (_event: MouseEvent) => void;
-  private readonly _boundDocumentKeydown: (_event: KeyboardEvent) => void;
-  private readonly _onColumns = (v: StoreState['columns']) => this.columns(v);
+  private readonly root: HTMLElement;
+  private readonly button: HTMLButtonElement;
+  private readonly menu: HTMLElement;
+  private readonly list: HTMLElement;
+  private draggingElement: HTMLElement | null = null;
+  private ghostElement: HTMLElement | null = null;
+  private draggingCursorStyleEl: HTMLStyleElement | null = null;
+  private clearPendingLongPress: (() => void) | null = null;
+  private cleanupDragListeners: (() => void) | null = null;
+  private suppressNextListClick = false;
+  private hoverCloseTimer: number | null = null;
+  private readonly eventAbortController = new AbortController();
+  private readonly boundDocumentClick: (_event: MouseEvent) => void;
+  private readonly boundDocumentKeydown: (_event: KeyboardEvent) => void;
+  private readonly onColumns = (v: StoreState['columns']) => this.columns(v);
 
   constructor(root: HTMLElement) {
-    this._root = root;
-    this._button = root.querySelector(SELECTORS.BUTTON) as HTMLButtonElement;
-    this._menu = root.querySelector(SELECTORS.MENU) as HTMLElement;
-    this._list = root.querySelector(SELECTORS.LIST) as HTMLElement;
-    this._boundDocumentClick = this._handleDocumentClick.bind(this);
-    this._boundDocumentKeydown = this._handleDocumentKeydown.bind(this);
+    this.root = root;
+    this.button = root.querySelector(SELECTORS.BUTTON) as HTMLButtonElement;
+    this.menu = root.querySelector(SELECTORS.MENU) as HTMLElement;
+    this.list = root.querySelector(SELECTORS.LIST) as HTMLElement;
+    this.boundDocumentClick = this.handleDocumentClick.bind(this);
+    this.boundDocumentKeydown = this.handleDocumentKeydown.bind(this);
 
-    this._toggle(false);
-    this._bindEvents();
-    storeManager.subscribe('columns', this._onColumns);
+    this.toggle(false);
+    this.bindEvents();
+    storeManager.subscribe('columns', this.onColumns);
     this.columns(storeManager.getData('columns'));
   }
 
@@ -65,100 +65,92 @@ export class ResultsColumnsDropdown {
    * インスタンスを破棄（イベントリスナー削除、store バインド解除）
    */
   destroy(): void {
-    storeManager.unsubscribe('columns', this._onColumns);
-    this._clearPendingLongPress?.();
-    this._cancelHoverClose();
-    this._eventAbortController.abort();
-    this._cleanupDragListeners?.();
-    this._suppressNextListClick = false;
-    this._clearDragState();
+    storeManager.unsubscribe('columns', this.onColumns);
+    this.clearPendingLongPress?.();
+    this.cancelHoverClose();
+    this.eventAbortController.abort();
+    this.cleanupDragListeners?.();
+    this.suppressNextListClick = false;
+    this.clearDragState();
   }
 
   /**
    * 列設定を受け取り、UI を再描画
-   * - store.columns から呼ばれる（監視コールバック）
-   * - 固定列制約を適用（TogoVar ID は常に先頭）
-   * @param columns 列設定配列
    */
   columns(columns: ColumnConfig[]): void {
-    this._render(normalizeColumnConfigs(columns));
+    this.render(normalizeColumnConfigs(columns));
   }
 
   /**
    * 全イベントリスナーをセットアップ
-   * - hover/focus：ドロップダウン開閉
-   * - チェックボックス change：列表示/非表示制御
-   * - mousedown on drag-handle：列の並び替え（mousemove/mouseup ベース）
-   * - ドキュメントクリック/キー：ドロップダウン自動クローズ
    */
-  private _bindEvents(): void {
-    const { signal } = this._eventAbortController;
+  private bindEvents(): void {
+    const { signal } = this.eventAbortController;
 
     // hover：ドロップダウンメニューを開く
-    this._root.addEventListener(
+    this.root.addEventListener(
       'mouseenter',
       () => {
-        this._cancelHoverClose();
-        this._toggle(true);
+        this.cancelHoverClose();
+        this.toggle(true);
       },
       { signal }
     );
 
     // hover 解除：メニューとの隙間をまたぐため少し遅らせて閉じる
-    this._root.addEventListener(
+    this.root.addEventListener(
       'mouseleave',
       () => {
-        this._scheduleHoverClose();
+        this.scheduleHoverClose();
       },
       { signal }
     );
 
     // キーボード操作では focus で開き、フォーカスが外れたら閉じる
-    this._root.addEventListener(
+    this.root.addEventListener(
       'focusin',
       () => {
-        this._cancelHoverClose();
-        this._toggle(true);
+        this.cancelHoverClose();
+        this.toggle(true);
       },
       { signal }
     );
 
-    this._root.addEventListener(
+    this.root.addEventListener(
       'focusout',
       () => {
         window.setTimeout(() => {
           const activeElement = document.activeElement;
           if (
-            this._root.matches(':hover') ||
-            (activeElement instanceof Node &&
-              this._root.contains(activeElement))
+            this.root.matches(':hover') ||
+            (activeElement instanceof Node && this.root.contains(activeElement))
           ) {
             return;
           }
 
-          this._toggle(false);
+          this.toggle(false);
         }, 0);
       },
       { signal }
     );
 
     // ドラッグ終了後に発火する click で checkbox が誤って切り替わるのを防ぐ
-    this._list.addEventListener(
+    this.list.addEventListener(
       'click',
       (event) => {
-        if (!this._suppressNextListClick) {
+        if (!this.suppressNextListClick) {
           return;
         }
 
         event.preventDefault();
         event.stopPropagation();
-        this._suppressNextListClick = false;
+        this.suppressNextListClick = false;
       },
       { capture: true, signal }
     );
 
     // チェックボックス変更：列の表示/非表示を更新
-    this._list.addEventListener(
+    this.list.addEventListener(
       'change',
       (event) => {
         if (
@@ -174,12 +166,8 @@ export class ResultsColumnsDropdown {
           return;
         }
 
-        const nextColumns = normalizeColumnConfigs(
-          storeManager.getData('columns')
-        );
-        const targetColumn = nextColumns.find(
-          (column) => column.id === target.value
-        );
+        const nextColumns = normalizeColumnConfigs(storeManager.getData('columns'));
+        const targetColumn = nextColumns.find((column) => column.id === target.value);
 
         if (!targetColumn) {
           return;
@@ -192,8 +180,7 @@ export class ResultsColumnsDropdown {
     );
 
     // mousedown：checkbox 以外のエリアは長押しでドラッグ開始
-    // checkbox は通常クリックで表示/非表示切り替えを維持する
-    this._list.addEventListener(
+    this.list.addEventListener(
       'mousedown',
       (event) => {
         if (event.button !== 0) {
@@ -219,7 +206,7 @@ export class ResultsColumnsDropdown {
         const startX = event.clientX;
         const startY = event.clientY;
         let longPressTimer: number | null = null;
-        this._clearPendingLongPress?.();
+        this.clearPendingLongPress?.();
         const pendingAbortController = new AbortController();
 
         const clearLongPressWatchers = (): void => {
@@ -228,8 +215,8 @@ export class ResultsColumnsDropdown {
             longPressTimer = null;
           }
           pendingAbortController.abort();
-          if (this._clearPendingLongPress === clearLongPressWatchers) {
-            this._clearPendingLongPress = null;
+          if (this.clearPendingLongPress === clearLongPressWatchers) {
+            this.clearPendingLongPress = null;
           }
         };
 
@@ -249,10 +236,10 @@ export class ResultsColumnsDropdown {
 
         const startDrag = (): void => {
           clearLongPressWatchers();
-          this._beginDrag(item, startX, startY);
+          this.beginDrag(item, startX, startY);
         };
 
-        this._clearPendingLongPress = clearLongPressWatchers;
+        this.clearPendingLongPress = clearLongPressWatchers;
         longPressTimer = window.setTimeout(startDrag, LONG_PRESS_MS);
         document.addEventListener('mousemove', onPendingMove, {
           signal: pendingAbortController.signal,
@@ -265,21 +252,16 @@ export class ResultsColumnsDropdown {
     );
 
     // ドキュメントクリック：範囲外クリックでドロップダウンを閉じる
-    document.addEventListener('click', this._boundDocumentClick, { signal });
+    document.addEventListener('click', this.boundDocumentClick, { signal });
     // Escape キー：ドロップダウンを閉じる
-    document.addEventListener('keydown', this._boundDocumentKeydown, {
-      signal,
-    });
+    document.addEventListener('keydown', this.boundDocumentKeydown, { signal });
   }
 
   /**
    * 列リストを HTML にレンダリング
-   * - 固定列（TogoVar ID）は draggable="false"・チェック常時有効・鍵アイコン表示
-   * - その他の列はドラッグハンドル表示（Font Awesome グリップアイコン）
-   * @param columns レンダリング対象の列設定配列
    */
-  private _render(columns: ColumnConfig[]): void {
-    this._list.innerHTML = columns
+  private render(columns: ColumnConfig[]): void {
+    this.list.innerHTML = columns
       .map((column) => {
         const isLocked = column.id === LOCKED_COLUMN_ID;
         return `
@@ -298,21 +280,13 @@ export class ResultsColumnsDropdown {
 
   /**
    * 現在の DOM 上の列順を読み込み、store に保存
-   * - ドラッグ終了時に呼ばれる
-   * - 表示/非表示状態は保持
-   * - 固定列制約を再度適用（安全性確保）
    */
-  private _commitCurrentOrder(): void {
-    const currentColumns = normalizeColumnConfigs(
-      storeManager.getData('columns')
-    );
-    const columnMap = new Map(
-      currentColumns.map((column) => [column.id, column])
-    );
+  private commitCurrentOrder(): void {
+    const currentColumns = normalizeColumnConfigs(storeManager.getData('columns'));
+    const columnMap = new Map(currentColumns.map((column) => [column.id, column]));
 
-    // DOM の現在の並び順から新しい列設定を作成
     const domItems = Array.from(
-      this._list.querySelectorAll(SELECTORS.ITEM)
+      this.list.querySelectorAll(SELECTORS.ITEM)
     ) as HTMLElement[];
     const nextColumns = domItems
       .map((item) => columnMap.get(item.dataset.columnId ?? ''))
@@ -323,19 +297,16 @@ export class ResultsColumnsDropdown {
 
   /**
    * 実ドラッグ処理を開始
-   * - カーソル固定
-   * - ゴースト作成
-   * - mousemove/mouseup 監視登録
    */
-  private _beginDrag(
+  private beginDrag(
     item: HTMLElement,
     startClientX: number,
     startClientY: number
   ): void {
-    this._draggingElement = item;
-    this._suppressNextListClick = true;
-    this._list.classList.add('-is-dragging');
-    this._enableGlobalDraggingCursor();
+    this.draggingElement = item;
+    this.suppressNextListClick = true;
+    this.list.classList.add('-is-dragging');
+    this.enableGlobalDraggingCursor();
     item.classList.add('-dragging-hidden');
 
     // ゴースト要素を生成してカーソルに追従させる
@@ -356,21 +327,21 @@ export class ResultsColumnsDropdown {
       padding-left: 0;
     `;
     document.body.appendChild(ghost);
-    this._ghostElement = ghost;
+    this.ghostElement = ghost;
 
     // マウス位置とアイテム左上の差分（ドラッグ中にオフセットを保つ）
     const offsetX = startClientX - itemRect.left;
     const offsetY = startClientY - itemRect.top;
 
     const onMouseMove = (e: MouseEvent): void => {
-      if (!this._draggingElement) {
+      if (!this.draggingElement) {
         return;
       }
 
       // ゴーストをカーソルに追従
-      if (this._ghostElement) {
-        this._ghostElement.style.left = `${e.clientX - offsetX}px`;
-        this._ghostElement.style.top = `${e.clientY - offsetY}px`;
+      if (this.ghostElement) {
+        this.ghostElement.style.left = `${e.clientX - offsetX}px`;
+        this.ghostElement.style.top = `${e.clientY - offsetY}px`;
       }
 
       const target =
@@ -378,7 +349,7 @@ export class ResultsColumnsDropdown {
           ? (e.target.closest(SELECTORS.ITEM) as HTMLElement | null)
           : null;
 
-      if (!target || target === this._draggingElement) {
+      if (!target || target === this.draggingElement) {
         return;
       }
 
@@ -390,7 +361,7 @@ export class ResultsColumnsDropdown {
 
       // FLIP：移動前の各アイテムの Y 座標を記録
       const items = Array.from(
-        this._list.querySelectorAll(SELECTORS.ITEM)
+        this.list.querySelectorAll(SELECTORS.ITEM)
       ) as HTMLElement[];
       const beforeTops = new Map(
         items.map((el) => [el, el.getBoundingClientRect().top])
@@ -398,16 +369,15 @@ export class ResultsColumnsDropdown {
 
       // DOM を並び替え
       if (shouldInsertAfter) {
-        target.after(this._draggingElement);
+        target.after(this.draggingElement);
       } else {
-        target.before(this._draggingElement);
+        target.before(this.draggingElement);
       }
 
       // FLIP：移動後の差分を transform で補正し、短い transition でアニメーション
       items.forEach((el) => {
-        if (el === this._draggingElement) return;
-        const delta =
-          (beforeTops.get(el) ?? 0) - el.getBoundingClientRect().top;
+        if (el === this.draggingElement) return;
+        const delta = (beforeTops.get(el) ?? 0) - el.getBoundingClientRect().top;
         if (delta === 0) return;
         el.style.transition = 'none';
         el.style.transform = `translateY(${delta}px)`;
@@ -421,21 +391,21 @@ export class ResultsColumnsDropdown {
     const dragAbortController = new AbortController();
     const cleanupDragListeners = (): void => {
       dragAbortController.abort();
-      if (this._cleanupDragListeners === cleanupDragListeners) {
-        this._cleanupDragListeners = null;
+      if (this.cleanupDragListeners === cleanupDragListeners) {
+        this.cleanupDragListeners = null;
       }
     };
 
     const onMouseUp = (): void => {
       cleanupDragListeners();
-      this._commitCurrentOrder();
-      this._clearDragState();
+      this.commitCurrentOrder();
+      this.clearDragState();
       window.setTimeout(() => {
-        this._suppressNextListClick = false;
+        this.suppressNextListClick = false;
       }, 0);
     };
 
-    this._cleanupDragListeners = cleanupDragListeners;
+    this.cleanupDragListeners = cleanupDragListeners;
     document.addEventListener('mousemove', onMouseMove, {
       signal: dragAbortController.signal,
     });
@@ -446,21 +416,19 @@ export class ResultsColumnsDropdown {
 
   /**
    * ドラッグ状態をリセット
-   * - ドラッグ中の CSS クラス（-dragging-hidden, -is-dragging）を全て削除
-   * - 内部状態変数を初期化
    */
-  private _clearDragState(): void {
-    this._draggingElement = null;
-    this._disableGlobalDraggingCursor();
+  private clearDragState(): void {
+    this.draggingElement = null;
+    this.disableGlobalDraggingCursor();
 
     // ゴースト要素を削除
-    if (this._ghostElement) {
-      this._ghostElement.remove();
-      this._ghostElement = null;
+    if (this.ghostElement) {
+      this.ghostElement.remove();
+      this.ghostElement = null;
     }
 
-    this._list.classList.remove('-is-dragging');
-    this._list.querySelectorAll(SELECTORS.ITEM).forEach((element) => {
+    this.list.classList.remove('-is-dragging');
+    this.list.querySelectorAll(SELECTORS.ITEM).forEach((element) => {
       const el = element as HTMLElement;
       el.classList.remove('-dragging-hidden');
       el.style.transform = '';
@@ -469,8 +437,8 @@ export class ResultsColumnsDropdown {
   }
 
   /** ドラッグ中のみ全体カーソルを grabbing に固定 */
-  private _enableGlobalDraggingCursor(): void {
-    if (this._draggingCursorStyleEl) {
+  private enableGlobalDraggingCursor(): void {
+    if (this.draggingCursorStyleEl) {
       return;
     }
 
@@ -478,75 +446,71 @@ export class ResultsColumnsDropdown {
     styleEl.textContent =
       'html, body, body * { cursor: grabbing !important; user-select: none !important; -webkit-user-select: none !important; }';
     document.head.appendChild(styleEl);
-    this._draggingCursorStyleEl = styleEl;
+    this.draggingCursorStyleEl = styleEl;
   }
 
   /** ドラッグ終了後に全体カーソル固定を解除 */
-  private _disableGlobalDraggingCursor(): void {
-    if (!this._draggingCursorStyleEl) {
+  private disableGlobalDraggingCursor(): void {
+    if (!this.draggingCursorStyleEl) {
       return;
     }
 
-    this._draggingCursorStyleEl.remove();
-    this._draggingCursorStyleEl = null;
+    this.draggingCursorStyleEl.remove();
+    this.draggingCursorStyleEl = null;
   }
 
   /** hover 解除後、少し遅らせてドロップダウンを閉じる */
-  private _scheduleHoverClose(): void {
-    this._cancelHoverClose();
-    this._hoverCloseTimer = window.setTimeout(() => {
-      this._hoverCloseTimer = null;
-      this._toggle(false);
+  private scheduleHoverClose(): void {
+    this.cancelHoverClose();
+    this.hoverCloseTimer = window.setTimeout(() => {
+      this.hoverCloseTimer = null;
+      this.toggle(false);
     }, HOVER_CLOSE_DELAY_MS);
   }
 
   /** hover クローズ予約をキャンセル */
-  private _cancelHoverClose(): void {
-    if (this._hoverCloseTimer === null) {
+  private cancelHoverClose(): void {
+    if (this.hoverCloseTimer === null) {
       return;
     }
 
-    window.clearTimeout(this._hoverCloseTimer);
-    this._hoverCloseTimer = null;
+    window.clearTimeout(this.hoverCloseTimer);
+    this.hoverCloseTimer = null;
   }
 
   /**
    * ドロップダウンメニューの開閉を切り替え
-   * - aria-expanded を自動更新（アクセシビリティ対応）
-   * @param forceOpen 強制的に開く場合は true、クローズは false、省略時は toggle
    */
-  private _toggle(forceOpen?: boolean): void {
-    const shouldOpen = forceOpen ?? !this._root.classList.contains('-open');
-    this._root.classList.toggle('-open', shouldOpen);
-    this._button.setAttribute('aria-expanded', String(shouldOpen));
-    this._menu.setAttribute('aria-hidden', String(!shouldOpen));
+  private toggle(forceOpen?: boolean): void {
+    const shouldOpen = forceOpen ?? !this.root.classList.contains('-open');
+    this.root.classList.toggle('-open', shouldOpen);
+    this.button.setAttribute('aria-expanded', String(shouldOpen));
+    this.menu.setAttribute('aria-hidden', String(!shouldOpen));
 
     if (shouldOpen) {
       // opacity アニメーション開始前に hidden を解除してメニューを DOM に戻す。
-      this._menu.hidden = false;
-      this._menu.removeAttribute('inert');
+      this.menu.hidden = false;
+      this.menu.removeAttribute('inert');
       // inert 非対応ブラウザ向け: フォーカス制御を復元する。
-      this._menu
+      this.menu
         .querySelectorAll<HTMLInputElement>(SELECTORS.INPUT)
         .forEach((input) => input.removeAttribute('tabindex'));
     } else {
-      this._menu.setAttribute('inert', '');
+      this.menu.setAttribute('inert', '');
       // inert 非対応ブラウザ向け: フェードアウト中も Tab フォーカスがチェックボックスに入らないよう即座に遮断する。
-      this._menu
+      this.menu
         .querySelectorAll<HTMLInputElement>(SELECTORS.INPUT)
         .forEach((input) => input.setAttribute('tabindex', '-1'));
       // 既に hidden（display:none）なら transitionend は発火しないため即座に終了する。
-      // 範囲外クリックや Escape が連続して呼ばれてもリスナーが蓄積しない。
-      if (this._menu.hidden) {
+      if (this.menu.hidden) {
         return;
       }
       // CSS transition 完了後に hidden を設定する。
-      // 閉じるアニメーション中に再度開かれた場合は hidden を設定しない。
-      this._menu.addEventListener(
+      this.menu.addEventListener(
         'transitionend',
         () => {
-          if (!this._root.classList.contains('-open')) {
-            this._menu.hidden = true;
+          if (!this.root.classList.contains('-open')) {
+            this.menu.hidden = true;
           }
         },
         { once: true }
@@ -554,25 +518,19 @@ export class ResultsColumnsDropdown {
     }
   }
 
-  /**
-   * ドキュメント上のクリック処理
-   * - ドロップダウン範囲外がクリックされた場合、メニューを自動クローズ
-   */
-  private _handleDocumentClick(event: MouseEvent): void {
-    if (event.target instanceof Node && this._root.contains(event.target)) {
+  /** ドロップダウン範囲外がクリックされた場合、メニューを自動クローズ */
+  private handleDocumentClick(event: MouseEvent): void {
+    if (event.target instanceof Node && this.root.contains(event.target)) {
       return;
     }
 
-    this._toggle(false);
+    this.toggle(false);
   }
 
-  /**
-   * キーボード入力処理
-   * - Escape キー：ドロップダウンメニューを閉じる
-   */
-  private _handleDocumentKeydown(event: KeyboardEvent): void {
+  /** Escape キー：ドロップダウンメニューを閉じる */
+  private handleDocumentKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
-      this._toggle(false);
+      this.toggle(false);
     }
   }
 }

--- a/app/frontend/src/components/Results/ResultsRowView.ts
+++ b/app/frontend/src/components/Results/ResultsRowView.ts
@@ -28,7 +28,6 @@ export class ResultsRowView {
    * unsubscribeで同一参照が必要なため、束縛済みコールバックをフィールドに保持する。
    */
   private onSelectedRow = (v: number | undefined) => this.selectedRow(v);
-  private onOffset = () => this.offset();
 
   /**
    * prepareTableDataでHTML生成直後に一括取得し、updateTableRowで毎回querySelectorを
@@ -60,8 +59,8 @@ export class ResultsRowView {
   polyphenFunction: HTMLDivElement | null = null;
 
   /**
-   * offsetとselectedRowの変化を受け取って行を再描画するためStoreにバインドする。
-   * 個別バインドにしているのは行インデックスに応じたデータを独立して取得・表示するため。
+   * 選択状態は行ごとにclassを切り替えるだけで済むため、selectedRowだけを購読する。
+   * offsetによる再描画は親側でまとめ、スクロール中の購読コールバック増加を避ける。
    */
   constructor(index: number) {
     this.index = index;
@@ -69,7 +68,6 @@ export class ResultsRowView {
     this.tr = this.createTableRow();
 
     storeManager.subscribe('selectedRow', this.onSelectedRow);
-    storeManager.subscribe('offset', this.onOffset);
   }
 
   // ================================================================
@@ -84,7 +82,6 @@ export class ResultsRowView {
     if (this.isDestroyed) return;
 
     storeManager.unsubscribe('selectedRow', this.onSelectedRow);
-    storeManager.unsubscribe('offset', this.onOffset);
 
     if (this.tr && this.tr.parentNode) {
       this.tr.parentNode.removeChild(this.tr);
@@ -179,14 +176,6 @@ export class ResultsRowView {
     if (this.isDestroyed) return;
     this.selected = selectedIndex === this.index;
     this.tr.classList.toggle('-selected', this.selected);
-  }
-
-  /**
-   * offsetが変わると表示すべきデータが変わるため、行全体を再評価する。
-   */
-  offset() {
-    if (this.isDestroyed) return;
-    this.updateTableRow();
   }
 
   // ================================================================

--- a/app/frontend/src/components/Results/ResultsScrollBar.ts
+++ b/app/frontend/src/components/Results/ResultsScrollBar.ts
@@ -181,12 +181,7 @@ export class ResultsScrollBar {
       return;
     }
 
-    const newOffset = calculateTouchBasedRowOffset(
-      deltaY,
-      touchStartOffset,
-      visibleRowCount,
-      totalRecordCount
-    );
+    const newOffset = calculateTouchBasedRowOffset(deltaY, touchStartOffset);
     const boundedOffset = constrainRowOffsetToValidRange(
       newOffset,
       visibleRowCount,

--- a/app/frontend/src/components/Results/ResultsView.ts
+++ b/app/frontend/src/components/Results/ResultsView.ts
@@ -326,10 +326,11 @@ export class ResultsView {
     e.stopPropagation();
     if (e.deltaY === 0) return;
 
+    // WheelEvent が未定義の古いブラウザでも安全なよう、数値で比較する（LINE=1, PAGE=2）
     let delta = e.deltaY;
-    if (e.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+    if (e.deltaMode === 1) {
       delta = e.deltaY * TR_HEIGHT;
-    } else if (e.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+    } else if (e.deltaMode === 2) {
       delta = e.deltaY * storeManager.getData('rowCount') * TR_HEIGHT;
     }
 

--- a/app/frontend/src/components/Results/ResultsView.ts
+++ b/app/frontend/src/components/Results/ResultsView.ts
@@ -125,7 +125,11 @@ export class ResultsView {
 
   /** Store の offset 変化を受けて DataManager へ委譲する。 */
   offset(offset: number): void {
-    this.dataManager.handleOffsetChange(offset);
+    this.dataManager.handleOffsetChange(
+      offset,
+      isTouchDevice(),
+      this.touchHandler.setElementsInteractable.bind(this.touchHandler)
+    );
   }
 
   /** Store の searchMessages 変化を受けて DataManager へ委譲する。 */

--- a/app/frontend/src/components/Results/ResultsView.ts
+++ b/app/frontend/src/components/Results/ResultsView.ts
@@ -49,6 +49,9 @@ export class ResultsView {
   private resizeObserver: ResizeObserver | null = null;
   private mutationObserver: MutationObserver | null = null;
   private resizeFrameId: number | null = null;
+  // スクロール中に offset 更新のたびに .bind() が呼ばれないよう、安定参照としてフィールドに保持する
+  private readonly setInteractable = (enabled: boolean) =>
+    this.touchHandler.setElementsInteractable(enabled);
 
   // unsubscribe で同一参照が必要なため、束縛済みコールバックをフィールドに保持する
   private onSearchStatus = (v: StoreState['searchStatus']) => { if (v) this.searchStatus(v); };
@@ -128,7 +131,7 @@ export class ResultsView {
     this.dataManager.handleOffsetChange(
       offset,
       isTouchDevice(),
-      this.touchHandler.setElementsInteractable.bind(this.touchHandler)
+      this.setInteractable
     );
   }
 
@@ -150,7 +153,7 @@ export class ResultsView {
     this.dataManager.handleSearchResults(
       results,
       isTouchDevice(),
-      this.touchHandler.setElementsInteractable.bind(this.touchHandler)
+      this.setInteractable
     );
   }
 
@@ -165,7 +168,7 @@ export class ResultsView {
   updateDisplaySize(): void {
     this.dataManager.updateDisplaySize(
       isTouchDevice(),
-      this.touchHandler.setElementsInteractable.bind(this.touchHandler)
+      this.setInteractable
     );
   }
 

--- a/app/frontend/src/components/Results/ResultsView.ts
+++ b/app/frontend/src/components/Results/ResultsView.ts
@@ -1,5 +1,6 @@
 import { storeManager } from '../../store/StoreManager';
 import { getOrderedColumns } from '../../columns';
+import { TR_HEIGHT } from '../../global';
 import { ResultsScrollBar } from './ResultsScrollBar';
 import { ResultsColumnsDropdown } from './ResultsColumnsDropdown';
 import { keyDownEvent } from '../../utils/keyDownEvent';
@@ -22,209 +23,126 @@ const SELECTORS = {
   COLUMNS_DROPDOWN: '.columns-dropdown',
 } as const;
 
-
 /**
- * 検索結果テーブルビューを管理するクラス
- * - 行の描画、スクロール、タッチ操作、列管理を統合制御
- * - store の変更を監視し、自動的に UI を更新
+ * 検索結果テーブルビューを管理するクラス。
+ * 行の描画・スクロール・タッチ操作・列管理を統合制御し、
+ * Store の変更を監視して自動的に UI を更新する。
  */
 export class ResultsView {
-  /** ルート要素 */
   private elm: HTMLElement;
-  /** タッチ操作ハンドラー */
   private touchHandler!: ResultsViewTouchHandler;
-  /** スクロールバーコンポーネント */
   private scrollBar!: ResultsScrollBar;
-  /** テーブルデータと描画管理 */
   private dataManager!: ResultsViewDataManager;
-  /** テーブルヘッダー要素 */
   private thead!: HTMLElement;
-  /** テーブルボディ要素 */
   private tbody!: HTMLElement;
-  /** テーブルコンテナ要素 */
   private tablecontainer!: HTMLElement;
-  /** 列管理ドロップダウンコンポーネント */
   private columnsDropdown!: ResultsColumnsDropdown;
-  /** バインドされたキーボードイベントハンドラー */
-  private _boundKeydownHandler!: (_e: KeyboardEvent) => void;
-  /** バインドされたホイールイベントハンドラー */
-  private _boundWheelHandler!: EventListener;
-  /** ブラウザに応じたホイールイベント名 */
-  private _wheelEventName = '';
-  /** バインドされた検索モード変更ハンドラー */
-  private _boundSearchModeHandler!: (_newMode: unknown) => void;
-  /** 動的に作成した列表示制御用スタイル要素 */
-  private _stylesheet!: HTMLStyleElement;
   private columnAutoSizer!: ResultsColumnAutoSizer;
   private columnResizeController!: ResultsColumnResizeController;
-  private _resizeObserver: ResizeObserver | null = null;
-  private _mutationObserver: MutationObserver | null = null;
-  private _resizeFrameId: number | null = null;
-  private _boundResizeFallbackHandler: (() => void) | null = null;
+  private stylesheet!: HTMLStyleElement;
 
-  /** unsubscribeで同一参照が必要なため、束縛済みコールバックをフィールドに保持する。 */
-  private _onSearchStatus = (v: StoreState['searchStatus']) => { if (v) this.searchStatus(v); };
-  private _onSearchResults = (v: StoreState['searchResults']) => this.searchResults(v);
-  private _onColumns = (v: StoreState['columns']) => this.columns(v);
-  private _onOffset = (v: StoreState['offset']) => this.offset(v);
-  private _onKaryotype = (v: StoreState['karyotype']) => this.karyotype(v);
-  private _onSearchMessages = (v: StoreState['searchMessages']) => this.searchMessages(v ?? {});
+  private boundKeydownHandler!: (_e: KeyboardEvent) => void;
+  private boundWheelHandler!: EventListener;
+  private boundSearchModeHandler!: (_newMode: unknown) => void;
+  private boundResizeFallbackHandler: (() => void) | null = null;
+  private wheelEventName = '';
+  private resizeObserver: ResizeObserver | null = null;
+  private mutationObserver: MutationObserver | null = null;
+  private resizeFrameId: number | null = null;
 
-  /**
-   * ResultsView のコンストラクタ
-   * - DOM 要素を初期化
-   * - store バインドを設定
-   * - 各コンポーネント（スクロールバー、タッチハンドラー、データマネージャー）を初期化
-   * @param elm 検索結果表示用のルート要素
-   */
+  // unsubscribe で同一参照が必要なため、束縛済みコールバックをフィールドに保持する
+  private onSearchStatus = (v: StoreState['searchStatus']) => { if (v) this.searchStatus(v); };
+  private onSearchResults = (v: StoreState['searchResults']) => this.searchResults(v);
+  private onColumns = (v: StoreState['columns']) => this.columns(v);
+  private onOffset = (v: StoreState['offset']) => this.offset(v);
+  private onKaryotype = (v: StoreState['karyotype']) => this.karyotype(v);
+  private onSearchMessages = (v: StoreState['searchMessages']) => this.searchMessages(v ?? {});
+
   constructor(elm: HTMLElement) {
     this.elm = elm;
 
-    // DOM 要素の取得
     const { status, messages, thead, tbody, tablecontainer, columnsDropdown } =
-      this._getDOMElements();
+      this.getDOMElements();
     this.thead = thead;
     this.tbody = tbody;
     this.tablecontainer = tablecontainer;
 
-    // Store マネージャーへのバインド（変更監視）
-    this._connectToStoreManager();
+    this.connectToStoreManager();
+    this.configureScrollBar();
+    this.initializeTableHeader(thead, storeManager.getData('columns'));
+    this.stylesheet = this.createStylesheet();
 
-    // UI コンポーネントの初期化
-    this._configureScrollBar();
-    this._initializeTableHeader(thead, storeManager.getData('columns'));
-    this._stylesheet = this._createStylesheet();
-
-    // イベントハンドラー・コンポーネントの初期化
-    this._initializeComponentHandlers(status, messages, this._stylesheet);
+    this.initializeComponentHandlers(status, messages, this.stylesheet);
     this.columnsDropdown = new ResultsColumnsDropdown(columnsDropdown);
 
-    // 初期表示設定
-    this._configureInitialState();
-
-    // Search mode リスナー初期化
-    this._initializeSearchModeListener();
-
-    // 表示領域の変化に追従して仮想行数を再計算
-    this._observeDisplaySize();
+    this.configureInitialState();
+    this.initializeSearchModeListener();
+    this.observeDisplaySize();
   }
 
-  // ========================================
+  // ================================================================
   // Public Methods
-  // ========================================
+  // ================================================================
 
-  /**
-   * インスタンスをクリーンアップ
-   * - 全スコープのイベントリスナー・バインディングを削除
-   * - 子コンポーネント（ScrollBar、TouchHandler、DataManager、ColumnsDropdown）を破棄
-   * - メモリリーク防止のため、ResultsView 削除時は必ず呼び出す
-   */
+  /** 全イベントリスナーと子コンポーネントを破棄してメモリリークを防ぐ。 */
   destroy(): void {
-    // ScrollBar コンポーネントの破棄
-    if (this.scrollBar) {
-      this.scrollBar.destroy();
+    this.scrollBar?.destroy();
+    this.touchHandler?.destroy();
+    this.dataManager?.destroy();
+    this.columnsDropdown?.destroy();
+    this.columnResizeController?.destroy();
+    this.columnAutoSizer?.destroy();
+
+    storeManager.unsubscribe('searchStatus', this.onSearchStatus);
+    storeManager.unsubscribe('searchResults', this.onSearchResults);
+    storeManager.unsubscribe('columns', this.onColumns);
+    storeManager.unsubscribe('offset', this.onOffset);
+    storeManager.unsubscribe('karyotype', this.onKaryotype);
+    storeManager.unsubscribe('searchMessages', this.onSearchMessages);
+    storeManager.unsubscribe('searchMode', this.boundSearchModeHandler);
+
+    document.removeEventListener('keydown', this.boundKeydownHandler);
+
+    if (this.wheelEventName && this.boundWheelHandler) {
+      this.tbody.removeEventListener(this.wheelEventName, this.boundWheelHandler);
     }
 
-    // Clean up TouchHandler component
-    if (this.touchHandler) {
-      this.touchHandler.destroy();
-    }
+    this.stylesheet?.remove();
 
-    // Clean up DataManager component
-    if (this.dataManager) {
-      this.dataManager.destroy();
+    this.resizeObserver?.disconnect();
+    this.mutationObserver?.disconnect();
+    if (this.boundResizeFallbackHandler) {
+      window.removeEventListener('resize', this.boundResizeFallbackHandler);
     }
-
-    if (this.columnsDropdown) {
-      this.columnsDropdown.destroy();
+    if (this.resizeFrameId !== null) {
+      cancelAnimationFrame(this.resizeFrameId);
     }
-
-    if (this.columnResizeController) {
-      this.columnResizeController.destroy();
-    }
-
-    if (this.columnAutoSizer) {
-      this.columnAutoSizer.destroy();
-    }
-
-    storeManager.unsubscribe('searchStatus', this._onSearchStatus);
-    storeManager.unsubscribe('searchResults', this._onSearchResults);
-    storeManager.unsubscribe('columns', this._onColumns);
-    storeManager.unsubscribe('offset', this._onOffset);
-    storeManager.unsubscribe('karyotype', this._onKaryotype);
-    storeManager.unsubscribe('searchMessages', this._onSearchMessages);
-    storeManager.unsubscribe('searchMode', this._boundSearchModeHandler);
-
-    // Remove keydown event listener
-    document.removeEventListener('keydown', this._boundKeydownHandler);
-
-    if (this._wheelEventName && this._boundWheelHandler) {
-      this.tbody.removeEventListener(
-        this._wheelEventName,
-        this._boundWheelHandler
-      );
-    }
-
-    if (this._stylesheet) {
-      this._stylesheet.remove();
-    }
-
-    this._resizeObserver?.disconnect();
-    this._mutationObserver?.disconnect();
-    if (this._boundResizeFallbackHandler) {
-      window.removeEventListener('resize', this._boundResizeFallbackHandler);
-    }
-    if (this._resizeFrameId !== null) {
-      cancelAnimationFrame(this._resizeFrameId);
-    }
-    this._resizeObserver = null;
-    this._mutationObserver = null;
-    this._resizeFrameId = null;
-    this._boundResizeFallbackHandler = null;
+    this.resizeObserver = null;
+    this.mutationObserver = null;
+    this.resizeFrameId = null;
+    this.boundResizeFallbackHandler = null;
   }
 
-  /**
-   * テーブルスクロール位置（オフセット）を更新
-   * - store から呼ばれるコールバック
-   * - DataManager に処理を委譲
-   * @param offset 新しいオフセット値
-   */
+  /** Store の offset 変化を受けて DataManager へ委譲する。 */
   offset(offset: number): void {
     this.dataManager.handleOffsetChange(offset);
   }
 
-  /**
-   * 検索メッセージを表示更新
-   * - store から呼ばれるコールバック
-   * - DataManager に処理を委譲
-   * @param messages メッセージオブジェクト
-   */
+  /** Store の searchMessages 変化を受けて DataManager へ委譲する。 */
   searchMessages(messages: SearchMessages): void {
     this.dataManager.handleSearchMessages(messages);
   }
 
-  /**
-   * 検索ステータスを表示更新
-   * - store から呼ばれるコールバック
-   * - DataManager に処理を委譲
-   * @param status ステータスオブジェクト
-   */
+  /** Store の searchStatus 変化を受けて DataManager へ委譲する。 */
   searchStatus(status: SearchStatus): void {
     this.dataManager.handleSearchStatus(status);
   }
 
-  /**
-   * 検索結果テーブルを描画更新
-   * - store から呼ばれるコールバック
-   * - DataManager に処理を委譲
-   * - タッチデバイス判定を含める
-   * @param results 検索結果
-   */
+  /** Store の searchResults 変化を受けてテーブル行を再描画する。 */
   searchResults(results: unknown): void {
     if (!Array.isArray(results) || results.length === 0) {
       this.columnAutoSizer.resetSignature();
     }
-
     this.dataManager.handleSearchResults(
       results,
       isTouchDevice(),
@@ -232,23 +150,14 @@ export class ResultsView {
     );
   }
 
-  /**
-   * テーブルヘッダー（列）を再構成
-   * - store から呼ばれるコールバック
-   * - 列の表示/非表示、順序変更に対応
-   * - ヘッダーと本体の行セルを同期
-   * @param columns 列設定配列
-   */
+  /** Store の columns 変化を受けてヘッダーを再構築し表示サイズを再計算する。 */
   columns(columns: ColumnConfig[]): void {
-    this._initializeTableHeader(this.thead, columns);
+    this.initializeTableHeader(this.thead, columns);
     this.dataManager.handleColumnsChange(columns);
     this.updateDisplaySize();
   }
 
-  /**
-   * テーブル表示サイズを更新（外部からの呼び出し用）
-   * - ウィンドウリサイズ時など
-   */
+  /** 表示サイズを再計算する（ウィンドウリサイズなど外部からの呼び出し用）。 */
   updateDisplaySize(): void {
     this.dataManager.updateDisplaySize(
       isTouchDevice(),
@@ -256,62 +165,41 @@ export class ResultsView {
     );
   }
 
-  /**
-   * 核型変更時の処理
-   * - store から呼ばれるコールバック
-   * - 表示サイズ再計算をトリガー
-   * @param _karyotype 核型データ（_prefix は使用しないことを示す）
-   */
+  /** Store の karyotype 変化を受けて表示サイズを再計算する。 */
   karyotype(_karyotype: unknown): void {
     this.updateDisplaySize();
   }
 
-  // ========================================
+  // ================================================================
   // Private Methods
-  // ========================================
+  // ================================================================
 
-  /**
-   * 必要な DOM 要素を取得
-   * - ヘッダー・ステータス・メッセージ・テーブル・列ドロップダウン
-   * @returns DOM 要素オブジェクト
-   */
-  private _getDOMElements() {
-    const status = this.elm.querySelector(SELECTORS.STATUS) as HTMLElement;
-    const messages = this.elm.querySelector(SELECTORS.MESSAGES) as HTMLElement;
-    const thead = this.elm.querySelector(SELECTORS.TABLE_THEAD) as HTMLElement;
-    const tbody = this.elm.querySelector(SELECTORS.TABLE_TBODY) as HTMLElement;
-    const tablecontainer = this.elm.querySelector(
-      SELECTORS.TABLE_CONTAINER
-    ) as HTMLElement;
-    const columnsDropdown = this.elm.querySelector(
-      SELECTORS.COLUMNS_DROPDOWN
-    ) as HTMLElement;
-
-    return { status, messages, thead, tbody, tablecontainer, columnsDropdown };
+  /** 必要な DOM 要素をまとめて取得する。 */
+  private getDOMElements() {
+    return {
+      status: this.elm.querySelector(SELECTORS.STATUS) as HTMLElement,
+      messages: this.elm.querySelector(SELECTORS.MESSAGES) as HTMLElement,
+      thead: this.elm.querySelector(SELECTORS.TABLE_THEAD) as HTMLElement,
+      tbody: this.elm.querySelector(SELECTORS.TABLE_TBODY) as HTMLElement,
+      tablecontainer: this.elm.querySelector(SELECTORS.TABLE_CONTAINER) as HTMLElement,
+      columnsDropdown: this.elm.querySelector(SELECTORS.COLUMNS_DROPDOWN) as HTMLElement,
+    };
   }
 
-  /**
-   * ストアマネージャーに接続
-   * - 全ての store バインディングを設定
-   * - キーボードイベントリスナーを登録
-   */
-  private _connectToStoreManager(): void {
-    storeManager.subscribe('searchStatus', this._onSearchStatus);
-    storeManager.subscribe('searchResults', this._onSearchResults);
-    storeManager.subscribe('columns', this._onColumns);
-    storeManager.subscribe('offset', this._onOffset);
-    storeManager.subscribe('karyotype', this._onKaryotype);
-    storeManager.subscribe('searchMessages', this._onSearchMessages);
-    this._boundKeydownHandler = this._keydown.bind(this);
-    document.addEventListener('keydown', this._boundKeydownHandler);
+  /** Store へ購読登録してキーボードイベントリスナーを設定する。 */
+  private connectToStoreManager(): void {
+    storeManager.subscribe('searchStatus', this.onSearchStatus);
+    storeManager.subscribe('searchResults', this.onSearchResults);
+    storeManager.subscribe('columns', this.onColumns);
+    storeManager.subscribe('offset', this.onOffset);
+    storeManager.subscribe('karyotype', this.onKaryotype);
+    storeManager.subscribe('searchMessages', this.onSearchMessages);
+    this.boundKeydownHandler = this.keydown.bind(this);
+    document.addEventListener('keydown', this.boundKeydownHandler);
   }
 
-  /**
-   * スクロールバーコンポーネントを設定
-   * - テーブルコンテナの直後に scroll-bar 要素を挿入
-   * - ResultsScrollBar インスタンスを初期化
-   */
-  private _configureScrollBar(): void {
+  /** テーブルコンテナの直後に scroll-bar 要素を挿入して ResultsScrollBar を初期化する。 */
+  private configureScrollBar(): void {
     this.elm
       .querySelector(SELECTORS.TABLE_CONTAINER)!
       .insertAdjacentHTML('afterend', '<div class="scroll-bar"></div>');
@@ -321,70 +209,40 @@ export class ResultsView {
   }
 
   /**
-   * テーブルヘッダーを描画
-   * - store.columns を表示順に並べ替え
-   * - 各列ごとに th 要素を生成
-   * - tooltip ID を設定（アクセシビリティ対応）
-   * @param thead テーブルヘッダー要素
-   * @param columns 列設定配列
+   * テーブルヘッダーを描画する。
+   * 列の順序・リサイズバーの有無が変わっていない場合は再描画をスキップする。
    */
-  private _initializeTableHeader(
-    thead: HTMLElement,
-    columns: ColumnConfig[]
-  ): void {
+  private initializeTableHeader(thead: HTMLElement, columns: ColumnConfig[]): void {
     const orderedColumns = getOrderedColumns(columns);
     const currentColumnIds = Array.from(thead.querySelectorAll('th')).map(
-      (th) =>
-        orderedColumns.find((column) => th.classList.contains(column.id))?.id
+      (th) => orderedColumns.find((col) => th.classList.contains(col.id))?.id
     );
-    const nextColumnIds = orderedColumns.map((column) => column.id);
-    const resizeBarCount = orderedColumns.filter(
-      (column) => column.resizable !== false
-    ).length;
-    const hasResizeBars =
-      thead.querySelectorAll('.resize-bar').length === resizeBarCount;
+    const nextColumnIds = orderedColumns.map((col) => col.id);
+    const resizeBarCount = orderedColumns.filter((col) => col.resizable !== false).length;
+    const hasResizeBars = thead.querySelectorAll('.resize-bar').length === resizeBarCount;
 
-    if (
-      hasResizeBars &&
-      currentColumnIds.join(',') === nextColumnIds.join(',')
-    ) {
-      return;
-    }
+    if (hasResizeBars && currentColumnIds.join(',') === nextColumnIds.join(',')) return;
 
     thead.innerHTML = `<tr>${orderedColumns
       .map(
-        (column) =>
-          `<th class="${column.id}" data-column-id="${column.id}">` +
-          `<span data-tooltip-id="table-header-${column.id}">${column.label}</span>` +
-          (column.resizable === false
-            ? ''
-            : '<div class="resize-bar" aria-hidden="true"></div>') +
+        (col) =>
+          `<th class="${col.id}" data-column-id="${col.id}">` +
+          `<span data-tooltip-id="table-header-${col.id}">${col.label}</span>` +
+          (col.resizable === false ? '' : '<div class="resize-bar" aria-hidden="true"></div>') +
           '</th>'
       )
       .join('')}</tr>`;
   }
 
-  /**
-   * スタイルシートを作成
-   * - 動的に生成される CSS を head に追加
-   * @returns 作成されたスタイルシート要素
-   */
-  private _createStylesheet(): HTMLStyleElement {
+  /** 列表示制御用のスタイル要素を head に追加して返す。 */
+  private createStylesheet(): HTMLStyleElement {
     const stylesheet = document.createElement('style');
     document.getElementsByTagName('head')[0].appendChild(stylesheet);
     return stylesheet;
   }
 
-  /**
-   * コンポーネントハンドラーを初期化
-   * - タッチイベント処理（ResultsViewTouchHandler）
-   * - データ管理・行描画（ResultsViewDataManager）
-   * - 各ハンドラーを store バインディングに登録
-   * @param status ステータス表示要素
-   * @param messages メッセージ表示要素
-   * @param stylesheet 動的 CSS シートの参照
-   */
-  private _initializeComponentHandlers(
+  /** タッチハンドラー・DataManager を初期化してイベントを設定する。 */
+  private initializeComponentHandlers(
     status: HTMLElement,
     messages: HTMLElement,
     stylesheet: HTMLStyleElement
@@ -401,30 +259,18 @@ export class ResultsView {
       this.tbody,
       stylesheet
     );
-
-    // イベントハンドラー設定
-    this._configureEventHandlers();
+    this.configureEventHandlers();
   }
 
-  /**
-   * 初期表示状態を設定
-   * - 列設定を DataManager に反映
-   * - タッチデバイス判定で pointer-events を初期化
-   */
-  private _configureInitialState(): void {
-    // DataManager に初期列設定を通知
+  /** DataManager に初期列設定を通知し、デバイス種別に応じて pointer-events を設定する。 */
+  private configureInitialState(): void {
     this.dataManager.handleColumnsChange(storeManager.getData('columns'));
-
-    // PC では pointer-events を有効化、タッチデバイスは後で有効化
     this.touchHandler.setElementsInteractable(!isTouchDevice());
   }
 
   /**
-   * ブラウザで利用可能なホイールイベント名を取得
-   * - 標準：wheel
-   * - IE/古いブラウザ：mousewheel
-   * - Firefox 3.5 以前：DOMMouseScroll
-   * @returns イベント名
+   * ブラウザで利用可能なホイールイベント名を返す。
+   * 標準は 'wheel'、古い IE/Firefox は 'mousewheel'/'DOMMouseScroll'。
    */
   private getWheelEventName(): string {
     return 'onwheel' in document
@@ -434,17 +280,11 @@ export class ResultsView {
         : 'DOMMouseScroll';
   }
 
-  /**
-   * イベントハンドラーを設定
-   * - ホイールスクロール処理（PC）
-   * - タッチスクロール処理（モバイル）
-   * - スクロールバーのコールバック設定
-   */
-  private _configureEventHandlers(): void {
-    // PC 用ホイールイベント
-    this._wheelEventName = this.getWheelEventName();
-    this._boundWheelHandler = this._scroll.bind(this) as EventListener;
-    this.tbody.addEventListener(this._wheelEventName, this._boundWheelHandler);
+  /** ホイール・タッチ・列リサイズの各イベントハンドラーを設定する。 */
+  private configureEventHandlers(): void {
+    this.wheelEventName = this.getWheelEventName();
+    this.boundWheelHandler = this.scroll.bind(this) as EventListener;
+    this.tbody.addEventListener(this.wheelEventName, this.boundWheelHandler);
 
     this.columnAutoSizer = new ResultsColumnAutoSizer(this.tbody);
     this.columnResizeController = new ResultsColumnResizeController({
@@ -452,19 +292,18 @@ export class ResultsView {
       tbody: this.tbody,
       tablecontainer: this.tablecontainer,
       autoSizer: this.columnAutoSizer,
-      previewColumns: (columns) => {
-        this.dataManager.handleColumnsChange(columns);
-      },
+      previewColumns: (columns) => this.dataManager.handleColumnsChange(columns),
     });
 
-    // タッチハンドラーのスクロールコールバック設定
+    // タッチ開始時の offset を固定することで、スワイプ中の誤差積み上がりを防ぐ
+    let touchStartOffset = 0;
     this.touchHandler.setScrollCallbacks({
       onScrollStart: () => {
+        touchStartOffset = storeManager.getData('offset') || 0;
         this.scrollBar.setActive();
       },
       onScroll: (deltaY) => {
-        const currentOffset = storeManager.getData('offset') || 0;
-        this.scrollBar.handleScrollWithFeedback(deltaY, currentOffset);
+        this.scrollBar.handleScrollWithFeedback(deltaY, touchStartOffset);
       },
       onScrollEnd: () => {
         this.scrollBar.setInactive();
@@ -473,91 +312,73 @@ export class ResultsView {
   }
 
   /**
-   * ホイールスクロールイベント処理
-   * - テーブルのスクロール位置を更新
-   * - スクロールバーのビジュアルフィードバック
-   * @param e ホイールイベント
+   * ホイールスクロールを処理する。
+   * deltaMode を正規化して Firefox（ライン単位）やページ単位にも対応する。
    */
-  private _scroll(e: WheelEvent): void {
+  private scroll(e: WheelEvent): void {
     e.stopPropagation();
-    // 垂直スクロール以外は処理しない
     if (e.deltaY === 0) return;
 
-    this.scrollBar.handleScroll(e.deltaY);
+    let delta = e.deltaY;
+    if (e.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+      delta = e.deltaY * TR_HEIGHT;
+    } else if (e.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+      delta = e.deltaY * storeManager.getData('rowCount') * TR_HEIGHT;
+    }
+
+    this.scrollBar.handleScroll(delta);
   }
 
-  /**
-   * キーボード入力処理
-   * - 矢印キー（上下）：行選択の移動
-   * - Escape：選択解除
-   * @param e キーボードイベント
-   */
-  private _keydown(e: KeyboardEvent): void {
+  /** 矢印キーで行選択を移動し、Escape で選択解除する。 */
+  private keydown(e: KeyboardEvent): void {
     if (storeManager.getData('selectedRow') === undefined) return;
+    if (!keyDownEvent('selectedRow')) return;
 
-    if (keyDownEvent('selectedRow')) {
-      switch (e.key) {
-        case 'ArrowUp': // ↑ キー
-          this.dataManager.shiftSelectedRow(-1);
-          break;
-        case 'ArrowDown': // ↓ キー
-          this.dataManager.shiftSelectedRow(1);
-          break;
-        case 'Escape': // 選択を解除
-          storeManager.setData('selectedRow', undefined);
-          break;
-      }
+    switch (e.key) {
+      case 'ArrowUp':
+        this.dataManager.shiftSelectedRow(-1);
+        break;
+      case 'ArrowDown':
+        this.dataManager.shiftSelectedRow(1);
+        break;
+      case 'Escape':
+        storeManager.setData('selectedRow', undefined);
+        break;
     }
   }
 
-  /**
-   * 検索モード変更リスナーを初期化
-   * - 検索モード切り替え時にスクロール位置をリセット
-   */
-  private _initializeSearchModeListener(): void {
-    this._boundSearchModeHandler = (_newMode) => {
-      // 検索モード変更時にスクロール位置をリセット
-      this.scrollBar.resetScrollPosition();
-    };
-    storeManager.subscribe('searchMode', this._boundSearchModeHandler);
+  /** 検索モード切り替え時にスクロール位置をリセットするリスナーを登録する。 */
+  private initializeSearchModeListener(): void {
+    this.boundSearchModeHandler = () => this.scrollBar.resetScrollPosition();
+    storeManager.subscribe('searchMode', this.boundSearchModeHandler);
   }
 
   /**
-   * ResultsViewの高さはCSS flexで決まるため、自身の実寸変化を監視して行数だけJSで再計算する。
+   * ResultsView の高さは CSS flex で決まるため、
+   * 自身の実寸変化を監視して仮想行数だけを JS で再計算する。
    */
-  private _observeDisplaySize(): void {
+  private observeDisplaySize(): void {
     if (typeof ResizeObserver === 'undefined') {
-      this._boundResizeFallbackHandler = () => {
-        this._scheduleDisplaySizeUpdate();
-      };
-      window.addEventListener('resize', this._boundResizeFallbackHandler);
-      // ResizeObserver 非対応時の追加フォールバック:
-      // タブ切替・Drawer 開閉など「ウィンドウサイズが変わらないレイアウト変化」は
-      // window.resize では検出できないため、body の class / data-search-mode 変化を監視する。
-      this._mutationObserver = new MutationObserver(() => {
-        this._scheduleDisplaySizeUpdate();
-      });
-      this._mutationObserver.observe(document.body, {
+      this.boundResizeFallbackHandler = () => this.scheduleDisplaySizeUpdate();
+      window.addEventListener('resize', this.boundResizeFallbackHandler);
+      // タブ切替・Drawer 開閉など window.resize では検出できないレイアウト変化にも対応する
+      this.mutationObserver = new MutationObserver(() => this.scheduleDisplaySizeUpdate());
+      this.mutationObserver.observe(document.body, {
         attributes: true,
         attributeFilter: ['class', 'data-search-mode'],
       });
       return;
     }
 
-    this._resizeObserver = new ResizeObserver(() => {
-      this._scheduleDisplaySizeUpdate();
-    });
-    this._resizeObserver.observe(this.elm);
+    this.resizeObserver = new ResizeObserver(() => this.scheduleDisplaySizeUpdate());
+    this.resizeObserver.observe(this.elm);
   }
 
-  /**
-   * ResizeObserverは連続発火しやすいため、行数再計算を次フレームにまとめる。
-   */
-  private _scheduleDisplaySizeUpdate(): void {
-    if (this._resizeFrameId !== null) return;
-
-    this._resizeFrameId = requestAnimationFrame(() => {
-      this._resizeFrameId = null;
+  /** ResizeObserver の連続発火をまとめ、行数再計算を次フレームに遅延する。 */
+  private scheduleDisplaySizeUpdate(): void {
+    if (this.resizeFrameId !== null) return;
+    this.resizeFrameId = requestAnimationFrame(() => {
+      this.resizeFrameId = null;
       this.updateDisplaySize();
     });
   }

--- a/app/frontend/src/components/Results/ResultsViewDataManager.ts
+++ b/app/frontend/src/components/Results/ResultsViewDataManager.ts
@@ -1,5 +1,4 @@
 import { storeManager } from '../../store/StoreManager';
-import type { ResultsRowView } from './ResultsRowView';
 import { ResultsViewDisplayManager } from './ResultsViewDisplayManager';
 import type {
   SearchMessages,
@@ -17,7 +16,6 @@ interface SelectionState {
 
 export class ResultsViewDataManager {
   private container: HTMLElement;
-  private rows: ResultsRowView[] = [];
   private status: HTMLElement;
   private messages: HTMLElement;
   private isDestroyed = false;
@@ -124,13 +122,6 @@ export class ResultsViewDataManager {
 
   destroy(): void {
     if (this.isDestroyed) return;
-
-    this.rows.forEach((row) => {
-      if (row && typeof row.destroy === 'function') {
-        row.destroy();
-      }
-    });
-    this.rows = [];
 
     this.displayManager.destroy();
     this.isDestroyed = true;

--- a/app/frontend/src/components/Results/ResultsViewDataManager.ts
+++ b/app/frontend/src/components/Results/ResultsViewDataManager.ts
@@ -15,158 +15,87 @@ interface SelectionState {
   numberOfRecords: number;
 }
 
-/**
- * Manages data for the results view.
- * Handles displaying search results, interacting with the store, and managing rows.
- */
 export class ResultsViewDataManager {
-  private _container: HTMLElement; // Root element
-  private _rows: ResultsRowView[] = []; // Array of result row view instances
-  private _status: HTMLElement; // Status display element
-  private _messages: HTMLElement; // Message display element
-  private _isDestroyed = false; // Track if instance has been destroyed
+  private container: HTMLElement;
+  private rows: ResultsRowView[] = [];
+  private status: HTMLElement;
+  private messages: HTMLElement;
+  private isDestroyed = false;
+  private displayManager: ResultsViewDisplayManager;
 
-  _tbody: HTMLElement; // Table body element
-  _stylesheet: HTMLStyleElement; // Stylesheet for column display control
-
-  private _displayManager: ResultsViewDisplayManager;
-
-  /**
-   * Constructor for ResultsViewDataManager.
-   * @param _container - The root element for the results view.
-   * @param _status - The element for displaying status messages.
-   * @param _messages - The element for displaying search messages.
-   * @param _tbody - The table body element where rows are appended.
-   * @param _stylesheet - The stylesheet element for dynamic column styling.
-   */
   constructor(
-    _container: HTMLElement,
-    _status: HTMLElement,
-    _messages: HTMLElement,
-    _tbody: HTMLElement,
-    _stylesheet: HTMLStyleElement
+    container: HTMLElement,
+    status: HTMLElement,
+    messages: HTMLElement,
+    tbody: HTMLElement,
+    stylesheet: HTMLStyleElement
   ) {
-    this._container = _container;
-    this._status = _status;
-    this._messages = _messages;
-    this._tbody = _tbody;
-    this._stylesheet = _stylesheet;
-    this._displayManager = new ResultsViewDisplayManager(_tbody, _stylesheet);
+    this.container = container;
+    this.status = status;
+    this.messages = messages;
+    this.displayManager = new ResultsViewDisplayManager(tbody, stylesheet);
   }
 
   // ========================================
   // Display Management
   // ========================================
 
-  /**
-   * Updates the display size of the results view.
-   * Ensures rows are adjusted based on the available space and updates animations.
-   * @param isTouchDevice - Whether the device supports touch input.
-   * @param setTouchElementsPointerEvents - Function to control pointer-events for touch elements.
-   */
   updateDisplaySize(
     isTouchDevice: boolean,
     setTouchElementsPointerEvents: (_enabled: boolean) => void
   ): void {
-    if (this._isDestroyed) return;
-    this._displayManager.updateDisplaySize(
-      isTouchDevice,
-      setTouchElementsPointerEvents
-    );
+    if (this.isDestroyed) return;
+    this.displayManager.updateDisplaySize(isTouchDevice, setTouchElementsPointerEvents);
   }
 
-  /**
-   * Handles the display of search results.
-   * Delegates to ResultsViewDisplayManager and ensures retry logic is respected.
-   * @param _results - The search results (currently unused).
-   * @param isTouchDevice - Whether the device supports touch input.
-   * @param setTouchElementsPointerEvents - Function to control pointer-events for touch elements.
-   */
   handleSearchResults(
     _results: unknown,
     isTouchDevice: boolean,
     setTouchElementsPointerEvents: (_enabled: boolean) => void
   ): void {
-    this._displayManager.handleSearchResults(
-      isTouchDevice,
-      setTouchElementsPointerEvents
-    );
+    this.displayManager.handleSearchResults(isTouchDevice, setTouchElementsPointerEvents);
   }
 
-  /**
-   * Controls the visibility of columns in the results table.
-   * Applies styles to show or hide columns based on the provided configuration.
-   * @param columns - Array of column configuration objects.
-   */
   handleColumnsChange(columns: ColumnConfig[]): void {
-    this._displayManager.handleColumnsChange(columns);
+    this.displayManager.handleColumnsChange(columns);
   }
 
   // ========================================
   // Status and Messages Handling
   // ========================================
 
-  /**
-   * Displays search messages in the UI.
-   * Clears existing messages and appends new ones based on their type (notice, warning, error).
-   * @param messages - The object containing search messages.
-   */
   handleSearchMessages(messages: SearchMessages): void {
-    this._messages.innerHTML = '';
-
-    this._appendMessageIfExists(messages.notice, 'notice');
-    this._appendMessageIfExists(messages.warning, 'warning');
-    this._appendMessageIfExists(messages.error, 'error');
+    this.messages.innerHTML = '';
+    this.appendMessageIfExists(messages.notice, 'notice');
+    this.appendMessageIfExists(messages.warning, 'warning');
+    this.appendMessageIfExists(messages.error, 'error');
   }
 
-  /**
-   * Updates the search status in the UI.
-   * Displays the number of available and filtered variations.
-   * @param status - The object containing search status information.
-   */
   handleSearchStatus(status: SearchStatus): void {
     const { available, filtered } = status;
-
-    this._status.innerHTML =
+    this.status.innerHTML =
       `The number of available variations is ${available.toLocaleString()} ` +
       `out of <span class="highlight">${filtered.toLocaleString()}</span>.`;
-
-    this._updateNotFoundState(filtered === 0);
+    this.updateNotFoundState(filtered === 0);
   }
 
   // ========================================
   // Offset and Selection Handling
   // ========================================
 
-  /**
-   * Handles changes to the offset value.
-   * Updates the visible regions on the chromosome based on the new offset.
-   * @param offset - The new offset value.
-   */
   handleOffsetChange(_offset: number): void {
-    if (this._shouldSkipOffsetUpdate()) {
-      return;
-    }
+    if (this.shouldSkipOffsetUpdate()) return;
 
-    const displayingRegions = this._calculateDisplayingRegions();
+    const displayingRegions = this.calculateDisplayingRegions();
     if (Object.keys(displayingRegions).length > 0) {
       storeManager.setData('displayingRegionsOnChromosome', displayingRegions);
     }
   }
 
-  /**
-   * Moves the selected row in the specified direction.
-   * Updates the offset and selected row index accordingly.
-   * @param direction - The direction to move the selection (+1 for down, -1 for up).
-   */
   shiftSelectedRow(direction: number): void {
-    const state = this._getSelectionState();
-    const newIndex = this._calculateNewIndex(state, direction);
-    const adjustedOffset = this._adjustOffsetForSelection(
-      state,
-      newIndex,
-      direction
-    );
+    const state = this.getSelectionState();
+    const newIndex = this.calculateNewIndex(state, direction);
+    const adjustedOffset = this.adjustOffsetForSelection(state, newIndex, direction);
 
     if (adjustedOffset !== state.offset) {
       storeManager.setData('offset', adjustedOffset);
@@ -179,51 +108,32 @@ export class ResultsViewDataManager {
   // Lifecycle Management
   // ================================================================
 
-  /**
-   * Clean up all resources and row instances
-   * Call this method when the DataManager is no longer needed
-   */
   destroy(): void {
-    if (this._isDestroyed) return;
+    if (this.isDestroyed) return;
 
-    // Clean up all row instances
-    this._rows.forEach((row) => {
+    this.rows.forEach((row) => {
       if (row && typeof row.destroy === 'function') {
         row.destroy();
       }
     });
-    this._rows = [];
+    this.rows = [];
 
-    // Clean up display manager (if it has destroy method in the future)
-    // Note: ResultsViewDisplayManager doesn't currently have a destroy method
-
-    // Mark as destroyed to prevent further operations
-    this._isDestroyed = true;
-
-    // Note: DOM references are kept to avoid TypeScript null assertion issues
-    // The _isDestroyed flag ensures the instance won't be used after cleanup
+    this.displayManager.destroy();
+    this.isDestroyed = true;
   }
 
   // ========================================
   // Private Methods
   // ========================================
 
-  /**
-   * Checks if the offset update should be skipped.
-   * @returns True if the offset update should be skipped, false otherwise.
-   */
-  private _shouldSkipOffsetUpdate(): boolean {
+  private shouldSkipOffsetUpdate(): boolean {
     return (
       storeManager.getData('isSearchResultsUpdating') ||
       storeManager.getData('isSearchDataFetching')
     );
   }
 
-  /**
-   * Calculates the regions of the chromosome that are currently displayed.
-   * @returns An object mapping chromosome identifiers to their displaying regions.
-   */
-  private _calculateDisplayingRegions(): DisplayingRegions {
+  private calculateDisplayingRegions(): DisplayingRegions {
     const rowCount = storeManager.getData('rowCount');
     const chromosomePositions: { [key: string]: number[] } = {};
 
@@ -234,17 +144,10 @@ export class ResultsViewDataManager {
       }
     }
 
-    return this._convertToRegions(chromosomePositions);
+    return this.convertToRegions(chromosomePositions);
   }
 
-  /**
-   * Converts an array of chromosome positions to a regions object.
-   * @param chromosomePositions - The object containing arrays of chromosome positions.
-   * @returns An object mapping chromosome identifiers to their corresponding regions.
-   */
-  private _convertToRegions(chromosomePositions: {
-    [key: string]: number[];
-  }): DisplayingRegions {
+  private convertToRegions(chromosomePositions: { [key: string]: number[] }): DisplayingRegions {
     const regions: DisplayingRegions = {};
 
     for (const chromosome in chromosomePositions) {
@@ -258,37 +161,21 @@ export class ResultsViewDataManager {
     return regions;
   }
 
-  /**
-   * Appends a message to the messages element if it exists.
-   * @param message - The message string to append.
-   * @param type - The type of the message (e.g., notice, warning, error).
-   */
-  private _appendMessageIfExists(
-    message: string | undefined,
-    type: string
-  ): void {
+  private appendMessageIfExists(message: string | undefined, type: string): void {
     if (message) {
-      this._messages.innerHTML += `<div class="message -${type}">${message}</div>`;
+      this.messages.innerHTML += `<div class="message -${type}">${message}</div>`;
     }
   }
 
-  /**
-   * Updates the UI to reflect the state when no search results are found.
-   * @param isNotFound - True if the not found state is active, false otherwise.
-   */
-  private _updateNotFoundState(isNotFound: boolean): void {
+  private updateNotFoundState(isNotFound: boolean): void {
     if (isNotFound) {
-      this._container.classList.add('-not-found');
+      this.container.classList.add('-not-found');
     } else {
-      this._container.classList.remove('-not-found');
+      this.container.classList.remove('-not-found');
     }
   }
 
-  /**
-   * Retrieves the current selection state from the store.
-   * @returns An object representing the current selection state.
-   */
-  private _getSelectionState(): SelectionState {
+  private getSelectionState(): SelectionState {
     return {
       currentIndex: storeManager.getData('selectedRow'),
       rowCount: storeManager.getData('rowCount'),
@@ -297,26 +184,12 @@ export class ResultsViewDataManager {
     };
   }
 
-  /**
-   * Calculates a new index for the selected row based on the current state and direction.
-   * @param state - The current selection state.
-   * @param direction - The direction to move the selection (+1 or -1).
-   * @returns The calculated new index for the selected row.
-   */
-  private _calculateNewIndex(state: SelectionState, direction: number): number {
+  private calculateNewIndex(state: SelectionState, direction: number): number {
     const newIndex = (state.currentIndex ?? 0) + direction;
     return Math.max(0, Math.min(newIndex, state.rowCount - 1));
   }
 
-  /**
-   * Adjusts the offset value based on the selection movement.
-   * Ensures the selected row is visible and adjusts the offset if necessary.
-   * @param state - The current selection state.
-   * @param newIndex - The newly calculated index for the selected row.
-   * @param direction - The direction of the selection movement (+1 or -1).
-   * @returns The adjusted offset value.
-   */
-  private _adjustOffsetForSelection(
+  private adjustOffsetForSelection(
     state: SelectionState,
     newIndex: number,
     direction: number
@@ -324,10 +197,8 @@ export class ResultsViewDataManager {
     let { offset } = state;
 
     if (direction < 0 && newIndex === 0 && offset > 0) {
-      // Scroll up
       offset--;
     } else if (direction > 0 && newIndex === state.rowCount - 1) {
-      // Scroll down (only if within range)
       if (offset + newIndex < state.numberOfRecords - 1) {
         offset++;
       }

--- a/app/frontend/src/components/Results/ResultsViewDataManager.ts
+++ b/app/frontend/src/components/Results/ResultsViewDataManager.ts
@@ -83,7 +83,21 @@ export class ResultsViewDataManager {
   // Offset and Selection Handling
   // ========================================
 
-  handleOffsetChange(_offset: number): void {
+  /**
+   * offset変更時の行再描画はDisplayManagerへ集約し、行ごとの同期購読を避ける。
+   */
+  handleOffsetChange(
+    _offset: number,
+    isTouchDevice: boolean,
+    setTouchElementsPointerEvents: (_enabled: boolean) => void
+  ): void {
+    if (this.isDestroyed) return;
+
+    this.displayManager.requestRowsUpdate(
+      isTouchDevice,
+      setTouchElementsPointerEvents
+    );
+
     if (this.shouldSkipOffsetUpdate()) return;
 
     const displayingRegions = this.calculateDisplayingRegions();

--- a/app/frontend/src/components/Results/ResultsViewDisplayManager.ts
+++ b/app/frontend/src/components/Results/ResultsViewDisplayManager.ts
@@ -13,6 +13,12 @@ export class ResultsViewDisplayManager {
   private stylesheetVars: HTMLStyleElement;
   private tableContainer: HTMLElement | null;
   private columnStyleSignature = '';
+  private rowUpdateFrameId: number | null = null;
+  private pendingRenderReason: ResultsRenderReason = 'layout';
+  private pendingIsTouchDevice = false;
+  private pendingSetTouchElementsPointerEvents:
+    | ((_enabled: boolean) => void)
+    | null = null;
 
   constructor(tbody: HTMLElement, stylesheet: HTMLStyleElement) {
     this.tbody = tbody;
@@ -82,8 +88,29 @@ export class ResultsViewDisplayManager {
     this.applyColumnStyles(columns);
   }
 
-  /** stylesheetVars を DOM から除去する。DataManager の destroy 時に呼ぶこと。 */
+  /**
+   * offset連続更新を1フレームにまとめ、スクロール中の同期DOM更新を避ける。
+   */
+  requestRowsUpdate(
+    isTouchDevice: boolean,
+    setTouchElementsPointerEvents: (_enabled: boolean) => void,
+    renderReason: ResultsRenderReason = 'layout'
+  ): void {
+    this.updateRowsWithAnimation(
+      isTouchDevice,
+      setTouchElementsPointerEvents,
+      renderReason
+    );
+  }
+
+  /** 行Viewと遅延描画を残すと破棄後にStore参照が続くため、まとめて解除する。 */
   destroy(): void {
+    if (this.rowUpdateFrameId !== null) {
+      cancelAnimationFrame(this.rowUpdateFrameId);
+      this.rowUpdateFrameId = null;
+    }
+    this.rows.forEach((row) => row.destroy());
+    this.rows = [];
     this.stylesheetVars.remove();
   }
 
@@ -159,15 +186,32 @@ export class ResultsViewDisplayManager {
     setTouchElementsPointerEvents: (_enabled: boolean) => void,
     renderReason: ResultsRenderReason
   ): void {
-    requestAnimationFrame(() => {
+    this.pendingIsTouchDevice = isTouchDevice;
+    this.pendingSetTouchElementsPointerEvents = setTouchElementsPointerEvents;
+    this.pendingRenderReason =
+      this.pendingRenderReason === 'searchResults' ? 'searchResults' : renderReason;
+
+    if (this.rowUpdateFrameId !== null) return;
+
+    this.rowUpdateFrameId = requestAnimationFrame(() => {
+      const shouldResetTouchPointerEvents = this.pendingIsTouchDevice;
+      const pointerEventsCallback = this.pendingSetTouchElementsPointerEvents;
+      const nextRenderReason = this.pendingRenderReason;
+
+      this.rowUpdateFrameId = null;
+      this.pendingRenderReason = 'layout';
+      this.pendingSetTouchElementsPointerEvents = null;
+
       this.rows.forEach((row) => row.updateTableRow());
 
-      if (isTouchDevice) {
-        setTouchElementsPointerEvents(false);
+      if (shouldResetTouchPointerEvents && pointerEventsCallback) {
+        pointerEventsCallback(false);
       }
 
       window.dispatchEvent(
-        new CustomEvent('togovar:results-rendered', { detail: { reason: renderReason } })
+        new CustomEvent('togovar:results-rendered', {
+          detail: { reason: nextRenderReason },
+        })
       );
     });
   }

--- a/app/frontend/src/components/Results/ResultsViewDisplayManager.ts
+++ b/app/frontend/src/components/Results/ResultsViewDisplayManager.ts
@@ -7,18 +7,19 @@ const DISPLAY_CALCULATION_MARGIN = 2;
 type ResultsRenderReason = 'layout' | 'searchResults';
 
 export class ResultsViewDisplayManager {
-  private _rows: ResultsRowView[] = [];
-  private _tbody: HTMLElement;
-  private _stylesheet: HTMLStyleElement;
-  private _table: HTMLElement | null;
-  private _tableContainer: HTMLElement | null;
-  private _columnStyleSignature = '';
+  private rows: ResultsRowView[] = [];
+  private tbody: HTMLElement;
+  private stylesheet: HTMLStyleElement;
+  private stylesheetVars: HTMLStyleElement;
+  private tableContainer: HTMLElement | null;
+  private columnStyleSignature = '';
 
   constructor(tbody: HTMLElement, stylesheet: HTMLStyleElement) {
-    this._tbody = tbody;
-    this._stylesheet = stylesheet;
-    this._table = tbody.closest<HTMLElement>('table.results-view');
-    this._tableContainer = tbody.closest<HTMLElement>('.tablecontainer');
+    this.tbody = tbody;
+    this.stylesheet = stylesheet;
+    this.stylesheetVars = document.createElement('style');
+    document.head.appendChild(this.stylesheetVars);
+    this.tableContainer = tbody.closest<HTMLElement>('.tablecontainer');
   }
 
   // ========================================
@@ -33,14 +34,14 @@ export class ResultsViewDisplayManager {
     setTouchElementsPointerEvents: (_enabled: boolean) => void,
     renderReason: ResultsRenderReason = 'layout'
   ): void {
-    if (this._shouldSkipUpdate()) {
+    if (this.shouldSkipUpdate()) {
       return;
     }
 
-    const calculation = this._calculateDisplaySize();
-    this._ensureRowsExist(calculation.rowCount);
-    this._adjustOffset(calculation);
-    this._updateRowsWithAnimation(
+    const calculation = this.calculateDisplaySize();
+    this.ensureRowsExist(calculation.rowCount);
+    this.adjustOffset(calculation);
+    this.updateRowsWithAnimation(
       isTouchDevice,
       setTouchElementsPointerEvents,
       renderReason
@@ -54,9 +55,7 @@ export class ResultsViewDisplayManager {
     isTouchDevice: boolean,
     setTouchElementsPointerEvents: (_enabled: boolean) => void
   ): void {
-    const isSearchResultsUpdating = storeManager.getData(
-      'isSearchResultsUpdating'
-    );
+    const isSearchResultsUpdating = storeManager.getData('isSearchResultsUpdating');
     const isSearchDataFetching = storeManager.getData('isSearchDataFetching');
 
     if (isSearchResultsUpdating || isSearchDataFetching) {
@@ -66,24 +65,26 @@ export class ResultsViewDisplayManager {
       return;
     }
 
-    if (!this._validateData()) {
+    if (!this.validateData()) {
       console.warn('Data validation failed');
       return;
     }
 
-    this.updateDisplaySize(
-      isTouchDevice,
-      setTouchElementsPointerEvents,
-      'searchResults'
-    );
+    this.updateDisplaySize(isTouchDevice, setTouchElementsPointerEvents, 'searchResults');
   }
 
   /**
-   * 列表示はCSS変数で切り替えるため、列定義の変更時だけルール生成と値更新を行う。
+   * 列定義が変わるたびにルールと変数宣言を更新する。
+   * ルールは列IDが変わった時だけ再生成し、変数宣言は毎回上書きする。
    */
   handleColumnsChange(columns: ColumnConfig[]): void {
-    this._ensureColumnStyleRules(columns);
-    this._applyColumnStyles(columns);
+    this.ensureColumnStyleRules(columns);
+    this.applyColumnStyles(columns);
+  }
+
+  /** stylesheetVars を DOM から除去する。DataManager の destroy 時に呼ぶこと。 */
+  destroy(): void {
+    this.stylesheetVars.remove();
   }
 
   // ========================================
@@ -93,15 +94,15 @@ export class ResultsViewDisplayManager {
   /**
    * data取得中はResults側の行描画を待たせ、未取得行のloading増殖を防ぐ。
    */
-  private _shouldSkipUpdate(): boolean {
+  private shouldSkipUpdate(): boolean {
     return storeManager.getData('isSearchDataFetching');
   }
 
   /**
    * 表示可能な高さと総件数から、Storeへ共有する表示行数を一箇所で決める。
    */
-  private _calculateDisplaySize(): DisplaySizeCalculation {
-    const availableHeight = this._calculateAvailableHeight();
+  private calculateDisplaySize(): DisplaySizeCalculation {
+    const availableHeight = this.calculateAvailableHeight();
     const maxRowCount = Math.max(0, Math.floor(availableHeight / TR_HEIGHT));
     const numberOfRecords = storeManager.getData('numberOfRecords');
     const offset = storeManager.getData('offset');
@@ -109,86 +110,64 @@ export class ResultsViewDisplayManager {
 
     storeManager.setData('rowCount', rowCount);
 
-    return {
-      maxRowCount,
-      rowCount,
-      numberOfRecords,
-      offset,
-    };
+    return { maxRowCount, rowCount, numberOfRecords, offset };
   }
 
-  private _calculateAvailableHeight(): number {
-    const tbodyTop = this._tbody.getBoundingClientRect().top;
-    const containerBottom =
-      this._tableContainer?.getBoundingClientRect().bottom ?? 0;
-    const paddingBottom = this._getPixelStyle(
-      this._tableContainer,
-      'padding-bottom'
-    );
-    return (
-      containerBottom - tbodyTop - paddingBottom - DISPLAY_CALCULATION_MARGIN
-    );
+  private calculateAvailableHeight(): number {
+    const tbodyTop = this.tbody.getBoundingClientRect().top;
+    const containerBottom = this.tableContainer?.getBoundingClientRect().bottom ?? 0;
+    const paddingBottom = this.getPixelStyle(this.tableContainer, 'padding-bottom');
+    return containerBottom - tbodyTop - paddingBottom - DISPLAY_CALCULATION_MARGIN;
   }
 
   /**
    * 仮想スクロールで再利用する行Viewは、不足分だけ増やして既存行を作り直さない。
    */
-  private _ensureRowsExist(requiredRowCount: number): void {
-    while (this._rows.length < requiredRowCount) {
-      const rowIndex = this._rows.length;
+  private ensureRowsExist(requiredRowCount: number): void {
+    while (this.rows.length < requiredRowCount) {
+      const rowIndex = this.rows.length;
       const rowView = new ResultsRowView(rowIndex);
-      this._rows.push(rowView);
-      this._tbody.appendChild(rowView.tr);
+      this.rows.push(rowView);
+      this.tbody.appendChild(rowView.tr);
     }
   }
 
   /**
    * 末尾付近で空白が出ないよう、表示可能行数に合わせてoffsetを上方向へ詰める。
    */
-  private _adjustOffset(calculation: DisplaySizeCalculation): void {
+  private adjustOffset(calculation: DisplaySizeCalculation): void {
     const { maxRowCount, numberOfRecords, offset } = calculation;
-    const visibleRecords = numberOfRecords - offset;
-    const emptySpace = maxRowCount - visibleRecords;
+    const emptySpace = maxRowCount - (numberOfRecords - offset);
 
     if (emptySpace > 0) {
-      const newOffset = this._calculateAdjustedOffset(offset, emptySpace);
-      storeManager.setData('offset', newOffset);
+      storeManager.setData('offset', this.calculateAdjustedOffset(offset, emptySpace));
     }
   }
 
   /**
    * offsetは負にできないため、空白量が現在offsetを超える場合は先頭へ戻す。
    */
-  private _calculateAdjustedOffset(
-    currentOffset: number,
-    emptySpace: number
-  ): number {
-    if (currentOffset >= emptySpace) {
-      return currentOffset - emptySpace;
-    } else {
-      return 0;
-    }
+  private calculateAdjustedOffset(currentOffset: number, emptySpace: number): number {
+    return currentOffset >= emptySpace ? currentOffset - emptySpace : 0;
   }
 
   /**
    * DOM更新を次フレームへまとめ、行更新後に後続UIへ描画完了イベントを通知する。
    */
-  private _updateRowsWithAnimation(
+  private updateRowsWithAnimation(
     isTouchDevice: boolean,
     setTouchElementsPointerEvents: (_enabled: boolean) => void,
     renderReason: ResultsRenderReason
   ): void {
     requestAnimationFrame(() => {
-      this._rows.forEach((row) => row.updateTableRow());
+      this.rows.forEach((row) => row.updateTableRow());
 
       if (isTouchDevice) {
         setTouchElementsPointerEvents(false);
       }
 
       window.dispatchEvent(
-        new CustomEvent('togovar:results-rendered', {
-          detail: { reason: renderReason },
-        })
+        new CustomEvent('togovar:results-rendered', { detail: { reason: renderReason } })
       );
     });
   }
@@ -196,10 +175,9 @@ export class ResultsViewDisplayManager {
   /**
    * Store由来の値は外部更新されるため、描画前に最低限の構造だけ確認する。
    */
-  private _validateData(): boolean {
+  private validateData(): boolean {
     const results = storeManager.getData('searchResults');
     const numberOfRecords = storeManager.getData('numberOfRecords');
-
     return (
       Array.isArray(results) &&
       typeof numberOfRecords === 'number' &&
@@ -210,64 +188,50 @@ export class ResultsViewDisplayManager {
   /**
    * 列ごとのCSSルールは列ID構成が変わったときだけ再生成し、通常更新のコストを抑える。
    */
-  private _ensureColumnStyleRules(columns: ColumnConfig[]): void {
-    const signature = columns.map((column) => column.id).join('|');
-    if (signature === this._columnStyleSignature) return;
+  private ensureColumnStyleRules(columns: ColumnConfig[]): void {
+    const signature = columns.map((col) => col.id).join('|');
+    if (signature === this.columnStyleSignature) return;
 
-    this._stylesheet.textContent = columns
-      .map((column) => {
-        const displayProperty = `--results-column-${column.id}-display`;
-        const widthProperty = `--results-column-${column.id}-width`;
-        const headerRule =
-          `.tablecontainer > table.results-view th.${column.id} { ` +
-          `display: var(${displayProperty}, table-cell); ` +
-          `width: var(${widthProperty}); ` +
-          `min-width: var(${widthProperty}); ` +
-          `max-width: var(${widthProperty}); ` +
-          '}';
-        const bodyRule =
-          `.tablecontainer > table.results-view td.${column.id} { ` +
-          `display: var(${displayProperty}, table-cell); ` +
-          `width: var(${widthProperty}); ` +
-          `min-width: var(${widthProperty}); ` +
-          `max-width: var(${widthProperty}); ` +
-          '}';
-
-        return `${headerRule}\n${bodyRule}`;
+    this.stylesheet.textContent = columns
+      .map((col) => {
+        const d = `--results-column-${col.id}-display`;
+        const w = `--results-column-${col.id}-width`;
+        const shared = `display: var(${d}, table-cell); width: var(${w}); min-width: var(${w}); max-width: var(${w});`;
+        return [
+          `.tablecontainer > table.results-view th.${col.id} { ${shared} }`,
+          `.tablecontainer > table.results-view td.${col.id} { ${shared} }`,
+        ].join('\n');
       })
       .join('\n');
-    this._columnStyleSignature = signature;
+
+    this.columnStyleSignature = signature;
   }
 
   /**
-   * 列幅と表示状態はCSS変数だけを更新し、生成済みルールを使い回す。
+   * 列の表示状態と幅を CSS 変数宣言として stylesheetVars に書き込む。
+   * `<table>` の inline style ではなく独立した `<style>` 要素に持たせることで
+   * DevTools での確認を容易にし、inline style 属性を空に保つ。
    */
-  private _applyColumnStyles(columns: ColumnConfig[]): void {
-    if (!this._table) return;
-
-    columns.forEach((column) => {
-      const displayProperty = `--results-column-${column.id}-display`;
-      const widthProperty = `--results-column-${column.id}-width`;
-
-      this._table?.style.setProperty(
-        displayProperty,
-        column.isUsed ? 'table-cell' : 'none'
-      );
-
-      if (typeof column.width === 'number') {
-        this._table?.style.setProperty(widthProperty, `${column.width}px`);
-      } else {
-        this._table?.style.removeProperty(widthProperty);
+  private applyColumnStyles(columns: ColumnConfig[]): void {
+    const declarations = columns.flatMap((col) => {
+      const lines = [
+        `  --results-column-${col.id}-display: ${col.isUsed ? 'table-cell' : 'none'}`,
+      ];
+      if (typeof col.width === 'number') {
+        lines.push(`  --results-column-${col.id}-width: ${col.width}px`);
       }
+      return lines;
     });
+
+    this.stylesheetVars.textContent =
+      `.tablecontainer > table.results-view {\n${declarations.join(';\n')};\n}`;
   }
 
   /**
    * CSSの余白値は文字列なので、計算可能なpx値だけを数値として使う。
    */
-  private _getPixelStyle(elm: HTMLElement | null, property: string): number {
+  private getPixelStyle(elm: HTMLElement | null, property: string): number {
     if (!elm) return 0;
-
     const raw = getComputedStyle(elm).getPropertyValue(property).trim();
     if (!raw.endsWith('px')) return 0;
     const value = Number.parseFloat(raw);

--- a/app/frontend/src/components/Results/ResultsViewTouchHandler.ts
+++ b/app/frontend/src/components/Results/ResultsViewTouchHandler.ts
@@ -1,402 +1,222 @@
 import type { ScrollCallbacks, TouchState, TouchGesture } from '../../types';
 import { isTouchDevice } from '../../utils/deviceDetection';
 
-// Selector constant for touch target elements (excluding links for accessibility)
+// アクセシビリティ上、リンク要素はタッチ対象から除外する
 const TOUCH_ELEMENTS_SELECTOR =
   '.tablecontainer > table > tbody > tr, .tablecontainer > table > tbody > td, .tablecontainer > table > tbody > td *:not(a)';
 
-// Touch configuration constants
 const TOUCH_CONFIG = {
-  SCROLL_SENSITIVITY: 0.1, // Scroll sensitivity adjustment
-  SCROLL_THRESHOLD: 10, // Scroll detection threshold (pixels)
-  TAP_THRESHOLD: 300, // Tap detection threshold (milliseconds)
+  SCROLL_SENSITIVITY: 1.0, // ホイールスクロールと揃えた1:1の感度
+  SCROLL_THRESHOLD: 10,    // スクロール判定の最低移動量（px）
+  TAP_THRESHOLD: 300,      // タップ判定の最長時間（ms）
 } as const;
 
 /**
- * Touch event handler for table-based result interfaces
- *
- * This class provides comprehensive touch interaction management for tabular data displays.
- * It handles device detection, gesture recognition, and pointer event coordination to
- * deliver optimal user experience across different input methods.
- *
- * ## Key Features
- * - **Device Detection**: Automatically detects touch vs mouse/trackpad devices
- * - **Gesture Recognition**: Distinguishes between taps and scroll gestures
- * - **Pointer Event Management**: Controls element interactivity during touch operations
- * - **Scroll Integration**: Provides callbacks for scroll-based data virtualization
- *
- * ## Usage Pattern
- * 1. Create handler with table DOM elements
- * 2. Configure scroll callbacks for data updates
- * 3. Handler automatically manages touch vs mouse interactions
+ * テーブル形式の検索結果に対するタッチ操作ハンドラー。
+ * タップとスクロールジェスチャーを識別し、仮想スクロールとの連携を担う。
  */
 export class ResultsViewTouchHandler {
-  private _container: HTMLElement;
-  private _tbody: HTMLElement;
-  private _tablecontainer: HTMLElement;
-  private _isDestroyed = false;
-  private _touchState: TouchState = {
+  private container: HTMLElement;
+  private tbody: HTMLElement;
+  private tablecontainer: HTMLElement;
+  private isDestroyed = false;
+  private touchState: TouchState = {
     startY: 0,
     startX: 0,
     startTime: 0,
-    lastY: 0,
-    lastX: 0,
     distance: 0,
-    duration: 0,
     isScrolling: false,
   };
-  private _scrollCallbacks: ScrollCallbacks = {};
+  private scrollCallbacks: ScrollCallbacks = {};
 
-  // Bound event handlers for proper cleanup
-  private readonly _boundHandlers = {
-    touchStart: this._handleTouchStart.bind(this),
-    touchMove: this._handleTouchMove.bind(this),
-    touchEnd: this._handleTouchEnd.bind(this),
-    tapCompleted: this._handleTapCompleted.bind(this),
+  // removeEventListener で同一参照が必要なため、束縛済みハンドラーをフィールドに保持する
+  private readonly boundHandlers = {
+    touchStart: this.handleTouchStart.bind(this),
+    touchMove: this.handleTouchMove.bind(this),
+    touchEnd: this.handleTouchEnd.bind(this),
+    tapCompleted: this.handleTapCompleted.bind(this),
   };
 
-  /**
-   * Create a new touch handler for table interactions
-   *
-   * @param _container - Root container element containing the table
-   * @param _tbody - Table body element where row interactions occur
-   * @param _tablecontainer - Table container element for scroll area
-   */
   constructor(
-    _container: HTMLElement,
-    _tbody: HTMLElement,
-    _tablecontainer: HTMLElement
+    container: HTMLElement,
+    tbody: HTMLElement,
+    tablecontainer: HTMLElement
   ) {
-    this._container = _container;
-    this._tbody = _tbody;
-    this._tablecontainer = _tablecontainer;
-
-    this._setupTouchEvents();
+    this.container = container;
+    this.tbody = tbody;
+    this.tablecontainer = tablecontainer;
+    this.setupTouchEvents();
   }
 
-  // ========================================
-  // Configuration & Callbacks
-  // ========================================
+  // ================================================================
+  // 設定・コールバック
+  // ================================================================
 
-  /**
-   * Configure scroll event callbacks
-   *
-   * Sets up callback functions that will be invoked during touch scroll operations.
-   * These callbacks allow external components to respond to scroll events.
-   *
-   * @param callbacks - Object containing optional callback functions:
-   *   - `onScrollStart`: Called when scroll gesture begins
-   *   - `onScroll`: Called during scroll with deltaY movement
-   *   - `onScrollEnd`: Called when scroll gesture ends
-   *
-   * @example
-   * ```typescript
-   * touchHandler.setScrollCallbacks({
-   *   onScrollStart: () => console.log('Scroll started'),
-   *   onScroll: (deltaY) => updateScrollPosition(deltaY),
-   *   onScrollEnd: () => console.log('Scroll ended')
-   * });
-   * ```
-   */
+  /** スクロール開始・中・終了の各タイミングで呼ばれるコールバックを登録する。 */
   setScrollCallbacks(callbacks: ScrollCallbacks): void {
-    if (this._isDestroyed) return;
-    this._scrollCallbacks = { ...callbacks };
+    if (this.isDestroyed) return;
+    this.scrollCallbacks = { ...callbacks };
   }
 
-  // ========================================
-  // Pointer Events Control
-  // ========================================
+  // ================================================================
+  // ポインターイベント制御
+  // ================================================================
 
   /**
-   * Control whether table elements can be touched/interacted with
-   *
-   * ## Use Cases
-   * - **Scroll Mode**: Make elements untouchable to prevent accidental taps during scrolling
-   * - **Normal Mode**: Make elements touchable after scroll gesture completes
-   * - **Gesture Recognition**: Temporarily make elements untouchable during gesture analysis
-   *
-   * @param enabled - Whether elements should be interactable
-   *   - `true`: Elements can be touched/clicked (normal interaction mode)
-   *   - `false`: Elements cannot be touched (scrolling mode)
+   * テーブル要素のインタラクティブ性を切り替える。
+   * スクロール中は誤タップを防ぐため false にし、ジェスチャー終了後に true へ戻す。
    */
   setElementsInteractable(enabled: boolean): void {
-    // Update pointer-events for all touch-sensitive table elements (excluding links)
-    const touchElements = this._container.querySelectorAll(
-      TOUCH_ELEMENTS_SELECTOR
-    );
-
-    touchElements.forEach((element) => {
-      (element as HTMLElement).style.pointerEvents = enabled ? 'auto' : 'none';
+    this.container.querySelectorAll(TOUCH_ELEMENTS_SELECTOR).forEach((el) => {
+      (el as HTMLElement).style.pointerEvents = enabled ? 'auto' : 'none';
     });
   }
 
   // ================================================================
-  // Lifecycle Management
+  // ライフサイクル管理
   // ================================================================
 
-  /**
-   * Clean up all resources and event listeners
-   * Call this method when the TouchHandler is no longer needed
-   */
+  /** イベントリスナーとコールバックをすべて解除してメモリリークを防ぐ。 */
   destroy(): void {
-    if (this._isDestroyed) return;
+    if (this.isDestroyed) return;
 
-    const touchElements = [this._tablecontainer, this._tbody];
-
-    // Remove touch event listeners
-    touchElements.forEach((element) => {
-      element.removeEventListener('touchstart', this._boundHandlers.touchStart);
-      element.removeEventListener('touchmove', this._boundHandlers.touchMove);
-      element.removeEventListener('touchend', this._boundHandlers.touchEnd);
+    [this.tablecontainer, this.tbody].forEach((el) => {
+      el.removeEventListener('touchstart', this.boundHandlers.touchStart);
+      el.removeEventListener('touchmove', this.boundHandlers.touchMove);
+      el.removeEventListener('touchend', this.boundHandlers.touchEnd);
     });
+    this.tbody.removeEventListener('tapCompleted', this.boundHandlers.tapCompleted);
 
-    // Remove tap completed listener
-    this._tbody.removeEventListener(
-      'tapCompleted',
-      this._boundHandlers.tapCompleted
-    );
-
-    // Clear callbacks
-    this._scrollCallbacks = {};
-
-    // Mark as destroyed to prevent further operations
-    this._isDestroyed = true;
-
-    // Note: DOM references are kept to avoid TypeScript null assertion issues
-    // The _isDestroyed flag ensures the instance won't be used after cleanup
+    this.scrollCallbacks = {};
+    this.isDestroyed = true;
   }
 
-  // ========================================
-  // Initialization & Setup
-  // ========================================
+  // ================================================================
+  // 初期化
+  // ================================================================
 
   /**
-   * Set up touch events
-   *
-   * ## Event Configuration
-   * - **passive: true**: Optimizes performance since we don't call preventDefault()
-   *   This allows the browser to perform scroll optimizations without waiting
-   *   to see if preventDefault() will be called.
+   * タッチイベントを登録する。
+   * passive: true により、preventDefault() を呼ばないことをブラウザに伝え
+   * スクロール最適化（合成スレッド処理）を有効にする。
    */
-  private _setupTouchEvents(): void {
-    const touchElements = [this._tablecontainer, this._tbody];
-
-    touchElements.forEach((element) => {
-      element.addEventListener('touchstart', this._boundHandlers.touchStart, {
-        passive: true,
-      });
-      element.addEventListener('touchmove', this._boundHandlers.touchMove, {
-        passive: true,
-      });
-      element.addEventListener('touchend', this._boundHandlers.touchEnd, {
-        passive: true,
-      });
+  private setupTouchEvents(): void {
+    [this.tablecontainer, this.tbody].forEach((el) => {
+      el.addEventListener('touchstart', this.boundHandlers.touchStart, { passive: true });
+      el.addEventListener('touchmove', this.boundHandlers.touchMove, { passive: true });
+      el.addEventListener('touchend', this.boundHandlers.touchEnd, { passive: true });
     });
-
-    this._tbody.addEventListener(
-      'tapCompleted',
-      this._boundHandlers.tapCompleted
-    );
+    this.tbody.addEventListener('tapCompleted', this.boundHandlers.tapCompleted);
   }
 
-  // ========================================
-  // Touch Event Handlers
-  // ========================================
+  // ================================================================
+  // タッチイベントハンドラー
+  // ================================================================
 
-  /**
-   * Handle touch start event - Initialize touch tracking
-   *
-   * This method is called when a user first touches the screen within the table area.
-   * It initializes the touch state tracking system and enables pointer events for
-   * normal interaction mode.
-   *
-   * @param e - TouchEvent containing touch point information
-   */
-  private _handleTouchStart(e: TouchEvent): void {
-    // Verify the touch is on a valid target with single finger
-    if (!this._isValidTouchTarget(e) || e.touches.length !== 1) {
-      return;
-    }
+  /** タッチ開始：状態を初期化し、ポインターイベントを有効化する。 */
+  private handleTouchStart(e: TouchEvent): void {
+    if (!this.isValidTouchTarget(e) || e.touches.length !== 1) return;
 
-    // Clear any previous touch state data
-    this._resetTouchState();
-
-    // Record initial touch positions and timestamp
+    this.resetTouchState();
     const touch = e.touches[0];
-    this._touchState.startY = touch.clientY;
-    this._touchState.startX = touch.clientX;
-    this._touchState.lastY = touch.clientY;
-    this._touchState.lastX = touch.clientX;
-    this._touchState.startTime = Date.now();
-
-    // Enable pointer events for touch elements
+    this.touchState.startY = touch.clientY;
+    this.touchState.startX = touch.clientX;
+    this.touchState.startTime = Date.now();
     this.setElementsInteractable(true);
   }
 
-  /**
-   * Handle touch move event - Process ongoing touch movement
-   *
-   * This method continuously tracks finger movement and determines user intent
-   * (scrolling vs accidental movement). It implements gesture recognition logic
-   * to distinguish between intentional scrolling and minor finger adjustments.
-   *
-   * @param e - TouchEvent containing current touch position
-   */
-  private _handleTouchMove(e: TouchEvent): void {
-    if (!this._isValidTouchTarget(e) || e.touches.length !== 1) {
-      return;
-    }
+  /** タッチ移動：スクロールジェスチャーを検知し、累積 deltaY をコールバックへ渡す。 */
+  private handleTouchMove(e: TouchEvent): void {
+    if (!this.isValidTouchTarget(e) || e.touches.length !== 1) return;
 
     const touch = e.touches[0];
-    const gesture = this._analyzeTouchGesture(touch.clientY, touch.clientX);
+    const gesture = this.analyzeTouchGesture(touch.clientY, touch.clientX);
+    this.touchState.distance = gesture.distance;
 
-    // Update distance tracking
-    this._touchState.distance = gesture.distance;
+    if (!gesture.isScroll) return;
 
-    if (gesture.isScroll) {
-      // Handle scroll gesture initiation
-      if (!this._touchState.isScrolling) {
-        this._touchState.isScrolling = true;
-        this.setElementsInteractable(false);
-        this._scrollCallbacks.onScrollStart?.();
-      }
-
-      // Continue scroll gesture
-      this._touchState.lastY = touch.clientY;
-      this._scrollCallbacks.onScroll?.(
-        -gesture.deltaY * TOUCH_CONFIG.SCROLL_SENSITIVITY
-      );
-    }
-  }
-
-  /**
-   * Handle touch end event - Finalize gesture and restore interaction state
-   *
-   * This method determines the final classification of the completed touch gesture
-   * and restores appropriate interaction state. It handles three scenarios:
-   * successful taps, completed scrolls, and cancelled gestures.
-   *
-   * @param _e - TouchEvent (unused but required for event handler signature)
-   */
-  private _handleTouchEnd(_e: TouchEvent): void {
-    // Calculate total gesture duration
-    this._touchState.duration = Date.now() - this._touchState.startTime;
-
-    // Classify completed gesture
-    const isTap =
-      this._touchState.distance < TOUCH_CONFIG.SCROLL_THRESHOLD &&
-      this._touchState.duration < TOUCH_CONFIG.TAP_THRESHOLD;
-
-    // Handle gesture completion based on classification
-    if (isTap) {
-      // Successful tap - enable interactions for click processing
-      this.setElementsInteractable(true);
-    } else if (this._touchState.isScrolling) {
-      // Completed scroll - keep interactions disabled, notify completion
-      this._touchState.isScrolling = false;
+    if (!this.touchState.isScrolling) {
+      this.touchState.isScrolling = true;
       this.setElementsInteractable(false);
-      this._scrollCallbacks.onScrollEnd?.();
+      this.scrollCallbacks.onScrollStart?.();
+    }
+
+    this.scrollCallbacks.onScroll?.(-gesture.deltaY * TOUCH_CONFIG.SCROLL_SENSITIVITY);
+  }
+
+  /** タッチ終了：タップかスクロールかを判定して操作状態を復元する。 */
+  private handleTouchEnd(_e: TouchEvent): void {
+    const duration = Date.now() - this.touchState.startTime;
+    const isTap =
+      this.touchState.distance < TOUCH_CONFIG.SCROLL_THRESHOLD &&
+      duration < TOUCH_CONFIG.TAP_THRESHOLD;
+
+    if (isTap) {
+      this.setElementsInteractable(true);
+    } else if (this.touchState.isScrolling) {
+      this.touchState.isScrolling = false;
+      this.setElementsInteractable(false);
+      this.scrollCallbacks.onScrollEnd?.();
     } else {
-      // Cancelled or unrecognized gesture - enable interactions (safe fallback)
       this.setElementsInteractable(true);
     }
 
-    // Clean up for next gesture
-    this._resetTouchState();
+    this.resetTouchState();
   }
 
   /**
-   * Handle tap completion event - Restore scroll-optimized interaction state
-   *
-   * This method is triggered after a successful tap gesture has been processed
-   * by the UI system. For touch devices, it restores the scroll-optimized state
-   * by disabling pointer events, preventing accidental interactions during
-   * subsequent scroll gestures.
-   *
-   * ## Touch Device Behavior
-   * - **Touch Devices**: Disable interactions to prepare for scrolling
-   * - **Non-Touch Devices**: No action (precise pointer control available)
-   *
-   * @param _e - Custom Event (unused but required for event handler signature)
+   * タップ完了後、タッチデバイスでは次のスクロールに備えてポインターイベントを無効化する。
+   * PC（正確なポインター操作が可能）では何もしない。
    */
-  private _handleTapCompleted(_e: Event): void {
+  private handleTapCompleted(_e: Event): void {
     if (!isTouchDevice()) return;
     this.setElementsInteractable(false);
   }
 
-  // ========================================
-  // Gesture Analysis
-  // ========================================
+  // ================================================================
+  // ジェスチャー解析
+  // ================================================================
 
   /**
-   * Analyze touch gesture to determine user intention (tap vs scroll)
-   *
-   * This method calculates the distance and direction of touch movement
-   * to distinguish between different types of gestures:
-   * - **Tap**: Short duration, minimal movement
-   * - **Scroll**: Vertical movement exceeding threshold
-   *
-   * @param currentY - Current Y coordinate of touch point
-   * @param currentX - Current X coordinate of touch point
-   * @returns Gesture analysis result containing:
-   *   - `isTap`: Whether gesture qualifies as a tap
-   *   - `isScroll`: Whether gesture qualifies as a scroll
-   *   - `deltaY`, `deltaX`: Movement deltas from start position
-   *   - `distance`: Euclidean distance (calculated once for efficiency)
+   * 現在のタッチ座標からジェスチャーを解析する。
+   * タッチ開始点からの累積移動量で判定し、縦方向かつ閾値超えをスクロールとみなす。
    */
-  private _analyzeTouchGesture(
-    currentY: number,
-    currentX: number
-  ): TouchGesture {
-    const deltaY = currentY - this._touchState.startY;
-    const deltaX = currentX - this._touchState.startX;
+  private analyzeTouchGesture(currentY: number, currentX: number): TouchGesture {
+    const deltaY = currentY - this.touchState.startY;
+    const deltaX = currentX - this.touchState.startX;
     const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
 
-    const isVerticalScroll = Math.abs(deltaY) > Math.abs(deltaX);
-    const exceedsThreshold = distance > TOUCH_CONFIG.SCROLL_THRESHOLD;
-    const isScroll = isVerticalScroll && exceedsThreshold;
+    const isScroll =
+      Math.abs(deltaY) > Math.abs(deltaX) &&
+      distance > TOUCH_CONFIG.SCROLL_THRESHOLD;
 
-    const duration = Date.now() - this._touchState.startTime;
+    const duration = Date.now() - this.touchState.startTime;
     const isTap =
       distance < TOUCH_CONFIG.SCROLL_THRESHOLD &&
       duration < TOUCH_CONFIG.TAP_THRESHOLD;
 
-    return {
-      isTap,
-      isScroll,
-      deltaY,
-      deltaX,
-      distance,
-    };
+    return { isTap, isScroll, deltaY, deltaX, distance };
   }
 
-  // ========================================
-  // Touch Validation & State Management
-  // ========================================
+  // ================================================================
+  // バリデーション・状態管理
+  // ================================================================
 
-  /**
-   * Check if touch is within valid range
-   */
-  private _isValidTouchTarget(e: TouchEvent): boolean {
+  /** タッチがこのコンポーネントの管轄要素上で発生したかどうかを検証する。 */
+  private isValidTouchTarget(e: TouchEvent): boolean {
     return (
-      (this._container.contains(e.target as Node) ||
-        this._container.contains(e.currentTarget as Node)) &&
-      (e.currentTarget === this._tablecontainer ||
-        e.currentTarget === this._tbody)
+      (this.container.contains(e.target as Node) ||
+        this.container.contains(e.currentTarget as Node)) &&
+      (e.currentTarget === this.tablecontainer || e.currentTarget === this.tbody)
     );
   }
 
-  /**
-   * Reset touch state
-   */
-  private _resetTouchState(): void {
-    this._touchState.isScrolling = false;
-    this._touchState.distance = 0;
-    this._touchState.startY = 0;
-    this._touchState.startX = 0;
-    this._touchState.lastY = 0;
-    this._touchState.lastX = 0;
-    this._touchState.startTime = 0;
-    this._touchState.duration = 0;
+  /** 次のジェスチャーに備えてタッチ状態をゼロクリアする。 */
+  private resetTouchState(): void {
+    this.touchState.startY = 0;
+    this.touchState.startX = 0;
+    this.touchState.startTime = 0;
+    this.touchState.distance = 0;
+    this.touchState.isScrolling = false;
   }
 }

--- a/app/frontend/src/components/Results/scroll/DragManager.ts
+++ b/app/frontend/src/components/Results/scroll/DragManager.ts
@@ -6,301 +6,203 @@ import type {
 import { supportsMouseInteraction } from '../../../utils/deviceDetection';
 
 /**
- * Class that manages drag functionality with support for both mouse and touch interactions
+ * マウスとタッチ両方のドラッグ操作を管理するクラス。
+ * スクロールバーのドラッグに特化し、座標計算とイベント管理を担う。
  */
 export class DragManager {
-  // Constants
-  private static readonly TOUCH_EVENT_OPTIONS: TouchEventOptions = {
-    passive: false,
-  };
+  private static readonly TOUCH_EVENT_OPTIONS: TouchEventOptions = { passive: false };
 
-  // State management
-  private _mouseDragState: DragState | undefined;
-  private _isTouchDragging: boolean = false;
-  private _touchStartY: number = 0;
-  private _touchStartTop: number = 0;
+  private mouseDragState: DragState | undefined;
+  private isTouchDragging = false;
+  private touchStartY = 0;
+  private touchStartTop = 0;
 
-  // DOM elements and callbacks
-  private readonly _scrollBarElement: HTMLElement;
-  private readonly _container: HTMLElement;
-  private readonly _onDragCallback: (_top: number) => void;
-  private readonly _onVisualStateChange: (_isDragging: boolean) => void;
+  private readonly scrollBarElement: HTMLElement;
+  private readonly container: HTMLElement;
+  private readonly onDragCallback: (_top: number) => void;
+  private readonly onVisualStateChange: (_isDragging: boolean) => void;
 
-  // Event handlers (bound methods for proper cleanup)
-  private readonly _boundMouseDown: (_e: MouseEvent) => void;
-  private readonly _boundMouseMove: (_e: MouseEvent) => void;
-  private readonly _boundMouseUp: () => void;
-  private readonly _boundTouchStart: (_e: TouchEvent) => void;
-  private readonly _boundTouchMove: (_e: TouchEvent) => void;
-  private readonly _boundTouchEnd: (_e: TouchEvent) => void;
+  // removeEventListener で同一参照が必要なため、束縛済みハンドラーをフィールドに保持する
+  private readonly boundMouseDown: (_e: MouseEvent) => void;
+  private readonly boundMouseMove: (_e: MouseEvent) => void;
+  private readonly boundMouseUp: () => void;
+  private readonly boundTouchStart: (_e: TouchEvent) => void;
+  private readonly boundTouchMove: (_e: TouchEvent) => void;
+  private readonly boundTouchEnd: (_e: TouchEvent) => void;
 
   constructor(config: DragManagerConfig) {
-    this._scrollBarElement = config.scrollBarElement;
-    this._container = config.container;
-    this._onDragCallback = config.onDragCallback;
-    this._onVisualStateChange = config.onVisualStateChange;
+    this.scrollBarElement = config.scrollBarElement;
+    this.container = config.container;
+    this.onDragCallback = config.onDragCallback;
+    this.onVisualStateChange = config.onVisualStateChange;
 
-    // Bind event handlers once for better performance and cleanup
-    this._boundMouseDown = this._onMouseDown.bind(this);
-    this._boundMouseMove = this._onMouseMove.bind(this);
-    this._boundMouseUp = this._onMouseUp.bind(this);
-    this._boundTouchStart = this._onTouchStart.bind(this);
-    this._boundTouchMove = this._onTouchMove.bind(this);
-    this._boundTouchEnd = this._onTouchEnd.bind(this);
+    this.boundMouseDown = this.handleMouseDown.bind(this);
+    this.boundMouseMove = this.handleMouseMove.bind(this);
+    this.boundMouseUp = this.handleMouseUp.bind(this);
+    this.boundTouchStart = this.handleTouchStart.bind(this);
+    this.boundTouchMove = this.handleTouchMove.bind(this);
+    this.boundTouchEnd = this.handleTouchEnd.bind(this);
   }
 
-  // ========================================
-  // Lifecycle Management
-  // ========================================
+  // ================================================================
+  // ライフサイクル管理
+  // ================================================================
 
   /**
-   * Initialize drag functionality by setting up event listeners
-   * Automatically detects device capabilities and configures appropriate interaction methods
+   * デバイス種別を判定してマウスまたはタッチのイベントリスナーを登録する。
    */
   initializeDragManager(): void {
-    if (this._supportsMouseInteraction()) {
-      this._initializeMouseDrag();
+    if (supportsMouseInteraction()) {
+      this.initializeMouseDrag();
     }
-    this._initializeTouchDrag();
+    this.initializeTouchDrag();
   }
 
   /**
-   * Clean up all event listeners and reset internal state
-   * Call this method when the component is no longer needed to prevent memory leaks
+   * 全イベントリスナーを解除して内部状態をリセットする。
    */
   destroyDragManager(): void {
-    this._removeMouseEventListeners();
-    this._removeTouchEventListeners();
-    this._resetState();
+    this.removeMouseEventListeners();
+    this.removeTouchEventListeners();
+    this.resetState();
   }
 
-  // ========================================
-  // Device Detection Methods
-  // ========================================
+  // ================================================================
+  // マウスドラッグ
+  // ================================================================
 
-  /**
-   * Check if device supports mouse interaction using shared utility
-   *
-   * @returns true for desktop/laptop with mouse/trackpad, false for touch-only devices
-   * @example
-   * Desktop with mouse: true
-   * Laptop with trackpad: true
-   * Tablet: false
-   * Smartphone: false
-   */
-  private _supportsMouseInteraction(): boolean {
-    return supportsMouseInteraction();
+  private initializeMouseDrag(): void {
+    this.mouseDragState = { isDragging: false, startY: 0, startTop: 0 };
+    this.attachMouseEventListeners();
   }
 
-  // ========================================
-  // Mouse Drag Implementation
-  // ========================================
-
-  /**
-   * Initialize mouse drag functionality
-   */
-  private _initializeMouseDrag(): void {
-    this._mouseDragState = {
-      isDragging: false,
-      startY: 0,
-      startTop: 0,
-    };
-
-    this._attachMouseEventListeners();
+  private attachMouseEventListeners(): void {
+    this.scrollBarElement.addEventListener('mousedown', this.boundMouseDown);
+    document.addEventListener('mousemove', this.boundMouseMove);
+    document.addEventListener('mouseup', this.boundMouseUp);
   }
 
-  /**
-   * Attach mouse event listeners
-   */
-  private _attachMouseEventListeners(): void {
-    this._scrollBarElement.addEventListener('mousedown', this._boundMouseDown);
-    document.addEventListener('mousemove', this._boundMouseMove);
-    document.addEventListener('mouseup', this._boundMouseUp);
+  private removeMouseEventListeners(): void {
+    this.scrollBarElement.removeEventListener('mousedown', this.boundMouseDown);
+    document.removeEventListener('mousemove', this.boundMouseMove);
+    document.removeEventListener('mouseup', this.boundMouseUp);
   }
 
-  /**
-   * Remove mouse event listeners safely
-   * This method is safe to call multiple times
-   */
-  private _removeMouseEventListeners(): void {
-    // Remove event listener from scrollbar element
-    this._scrollBarElement.removeEventListener(
-      'mousedown',
-      this._boundMouseDown
-    );
-
-    // Remove document-level event listeners (important)
-    document.removeEventListener('mousemove', this._boundMouseMove);
-    document.removeEventListener('mouseup', this._boundMouseUp);
-  }
-
-  // ========================================
-  // Mouse Event Handlers
-  // ========================================
-
-  /**
-   * Mouse down event handler
-   */
-  private _onMouseDown(e: MouseEvent): void {
-    if (!this._mouseDragState) return;
+  private handleMouseDown(e: MouseEvent): void {
+    if (!this.mouseDragState) return;
 
     e.preventDefault();
-    this._mouseDragState.isDragging = true;
-    this._mouseDragState.startY = e.clientY;
-    this._mouseDragState.startTop = this._getCurrentScrollBarTop();
+    this.mouseDragState.isDragging = true;
+    this.mouseDragState.startY = e.clientY;
+    this.mouseDragState.startTop = this.getCurrentScrollBarTop();
 
-    this._onVisualStateChange(true);
+    this.onVisualStateChange(true);
   }
 
-  /**
-   * Mouse move event handler
-   */
-  private _onMouseMove(e: MouseEvent): void {
-    if (!this._mouseDragState?.isDragging) return;
+  private handleMouseMove(e: MouseEvent): void {
+    if (!this.mouseDragState?.isDragging) return;
 
     e.preventDefault();
 
-    const deltaY = e.clientY - this._mouseDragState.startY;
-    const newTop = this._mouseDragState.startTop + deltaY;
-    const constrainedTop = this._constrainPositionWithinBounds(newTop);
+    const deltaY = e.clientY - this.mouseDragState.startY;
+    const newTop = this.mouseDragState.startTop + deltaY;
 
-    this._onDragCallback(constrainedTop);
+    this.onDragCallback(this.constrainPositionWithinBounds(newTop));
   }
 
-  /**
-   * Mouse up event handler
-   */
-  private _onMouseUp(): void {
-    if (!this._mouseDragState?.isDragging) return;
+  private handleMouseUp(): void {
+    if (!this.mouseDragState?.isDragging) return;
 
-    this._mouseDragState.isDragging = false;
-    this._onVisualStateChange(false);
+    this.mouseDragState.isDragging = false;
+    this.onVisualStateChange(false);
   }
 
-  // ========================================
-  // Touch Drag Implementation
-  // ========================================
+  // ================================================================
+  // タッチドラッグ
+  // ================================================================
 
-  /**
-   * Initialize touch drag functionality
-   */
-  private _initializeTouchDrag(): void {
-    this._attachTouchEventListeners();
+  private initializeTouchDrag(): void {
+    this.attachTouchEventListeners();
   }
 
-  /**
-   * Attach touch event listeners
-   */
-  private _attachTouchEventListeners(): void {
-    this._scrollBarElement.addEventListener(
+  private attachTouchEventListeners(): void {
+    this.scrollBarElement.addEventListener(
       'touchstart',
-      this._boundTouchStart,
+      this.boundTouchStart,
       DragManager.TOUCH_EVENT_OPTIONS
     );
-    this._scrollBarElement.addEventListener(
+    this.scrollBarElement.addEventListener(
       'touchmove',
-      this._boundTouchMove,
+      this.boundTouchMove,
       DragManager.TOUCH_EVENT_OPTIONS
     );
-    this._scrollBarElement.addEventListener(
+    this.scrollBarElement.addEventListener(
       'touchend',
-      this._boundTouchEnd,
+      this.boundTouchEnd,
       DragManager.TOUCH_EVENT_OPTIONS
     );
   }
 
-  /**
-   * Remove touch event listeners
-   */
-  private _removeTouchEventListeners(): void {
-    this._scrollBarElement.removeEventListener(
-      'touchstart',
-      this._boundTouchStart
-    );
-    this._scrollBarElement.removeEventListener(
-      'touchmove',
-      this._boundTouchMove
-    );
-    this._scrollBarElement.removeEventListener('touchend', this._boundTouchEnd);
+  private removeTouchEventListeners(): void {
+    this.scrollBarElement.removeEventListener('touchstart', this.boundTouchStart);
+    this.scrollBarElement.removeEventListener('touchmove', this.boundTouchMove);
+    this.scrollBarElement.removeEventListener('touchend', this.boundTouchEnd);
   }
 
-  // ========================================
-  // Touch Event Handlers
-  // ========================================
-
-  /**
-   * Touch start event handler
-   */
-  private _onTouchStart(e: TouchEvent): void {
+  private handleTouchStart(e: TouchEvent): void {
     e.preventDefault();
-    this._isTouchDragging = true;
-    this._touchStartY = e.touches[0].clientY;
-    this._touchStartTop = this._getCurrentScrollBarTop();
+    this.isTouchDragging = true;
+    this.touchStartY = e.touches[0].clientY;
+    this.touchStartTop = this.getCurrentScrollBarTop();
 
-    this._onVisualStateChange(true);
+    this.onVisualStateChange(true);
   }
 
-  /**
-   * Touch move event handler
-   */
-  private _onTouchMove(e: TouchEvent): void {
-    if (!this._isTouchDragging) return;
+  private handleTouchMove(e: TouchEvent): void {
+    if (!this.isTouchDragging) return;
     e.preventDefault();
 
-    const currentY = e.touches[0].clientY;
-    const deltaY = currentY - this._touchStartY;
-    const newTop = this._touchStartTop + deltaY;
-    const constrainedTop = this._constrainPositionWithinBounds(newTop);
+    const deltaY = e.touches[0].clientY - this.touchStartY;
+    const newTop = this.touchStartTop + deltaY;
 
-    this._onDragCallback(constrainedTop);
+    this.onDragCallback(this.constrainPositionWithinBounds(newTop));
   }
 
-  /**
-   * Touch end event handler
-   */
-  private _onTouchEnd(e: TouchEvent): void {
-    if (!this._isTouchDragging) return;
+  private handleTouchEnd(e: TouchEvent): void {
+    if (!this.isTouchDragging) return;
     e.preventDefault();
 
-    this._isTouchDragging = false;
-    this._onVisualStateChange(false);
+    this.isTouchDragging = false;
+    this.onVisualStateChange(false);
   }
 
-  // ========================================
-  // Position Management
-  // ========================================
+  // ================================================================
+  // 座標管理
+  // ================================================================
 
-  /**
-   * Get current scrollbar top position
-   */
-  private _getCurrentScrollBarTop(): number {
-    return parseInt(this._scrollBarElement.style.top) || 0;
+  private getCurrentScrollBarTop(): number {
+    return parseInt(this.scrollBarElement.style.top) || 0;
   }
 
   /**
-   * Constrain position within bounds
+   * スクロールバーがコンテナからはみ出さないよう top 値を制約する。
    */
-  private _constrainPositionWithinBounds(newTop: number): number {
-    const maxTop =
-      this._container.offsetHeight - this._scrollBarElement.offsetHeight;
+  private constrainPositionWithinBounds(newTop: number): number {
+    const maxTop = this.container.offsetHeight - this.scrollBarElement.offsetHeight;
     return Math.max(0, Math.min(newTop, maxTop));
   }
 
-  // ========================================
-  // State Management
-  // ========================================
+  // ================================================================
+  // 状態リセット
+  // ================================================================
 
-  /**
-   * Reset internal state without affecting DOM elements
-   * This method only clears internal tracking variables
-   */
-  private _resetState(): void {
-    if (this._mouseDragState) {
-      this._mouseDragState.isDragging = false;
-      this._mouseDragState = undefined;
+  private resetState(): void {
+    if (this.mouseDragState) {
+      this.mouseDragState.isDragging = false;
+      this.mouseDragState = undefined;
     }
-    this._isTouchDragging = false;
-    this._touchStartY = 0;
-    this._touchStartTop = 0;
+    this.isTouchDragging = false;
+    this.touchStartY = 0;
+    this.touchStartTop = 0;
   }
 }

--- a/app/frontend/src/components/Results/scroll/DragManager.ts
+++ b/app/frontend/src/components/Results/scroll/DragManager.ts
@@ -71,23 +71,36 @@ export class DragManager {
   // マウスドラッグ
   // ================================================================
 
+  /**
+   * マウスドラッグ状態オブジェクトを初期化し、リスナーを登録する。
+   * mousemove/mouseup はスクロールバー外でも追従する必要があるため document に登録する。
+   */
   private initializeMouseDrag(): void {
     this.mouseDragState = { isDragging: false, startY: 0, startTop: 0 };
     this.attachMouseEventListeners();
   }
 
+  /**
+   * mousedown はスクロールバー上、move/up は document に登録してドラッグ中のカーソル追従を保証する。
+   */
   private attachMouseEventListeners(): void {
     this.scrollBarElement.addEventListener('mousedown', this.boundMouseDown);
     document.addEventListener('mousemove', this.boundMouseMove);
     document.addEventListener('mouseup', this.boundMouseUp);
   }
 
+  /**
+   * removeEventListener は登録時と同じ参照が必要なため、boundXxx フィールドで解除する。
+   */
   private removeMouseEventListeners(): void {
     this.scrollBarElement.removeEventListener('mousedown', this.boundMouseDown);
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
   }
 
+  /**
+   * ドラッグ開始時点の座標とスクロールバー位置を記録し、以降の move で差分計算できるようにする。
+   */
   private handleMouseDown(e: MouseEvent): void {
     if (!this.mouseDragState) return;
 
@@ -99,6 +112,9 @@ export class DragManager {
     this.onVisualStateChange(true);
   }
 
+  /**
+   * 開始位置との差分だけ top を動かすことで、クリック位置を起点にした自然なドラッグを実現する。
+   */
   private handleMouseMove(e: MouseEvent): void {
     if (!this.mouseDragState?.isDragging) return;
 
@@ -110,6 +126,10 @@ export class DragManager {
     this.onDragCallback(this.constrainPositionWithinBounds(newTop));
   }
 
+  /**
+   * isDragging フラグをクリアしてドラッグ終了を通知する。
+   * mouseup が document に登録されているため、スクロールバー外で離しても確実に終了できる。
+   */
   private handleMouseUp(): void {
     if (!this.mouseDragState?.isDragging) return;
 
@@ -121,10 +141,16 @@ export class DragManager {
   // タッチドラッグ
   // ================================================================
 
+  /**
+   * タッチドラッグはマウスと異なりデバイス非依存で常に登録する。
+   */
   private initializeTouchDrag(): void {
     this.attachTouchEventListeners();
   }
 
+  /**
+   * passive: false でスクロールバードラッグ中のページスクロールを抑制する。
+   */
   private attachTouchEventListeners(): void {
     this.scrollBarElement.addEventListener(
       'touchstart',
@@ -143,12 +169,18 @@ export class DragManager {
     );
   }
 
+  /**
+   * addEventListener と同じ参照・オプションで登録したリスナーを解除する。
+   */
   private removeTouchEventListeners(): void {
     this.scrollBarElement.removeEventListener('touchstart', this.boundTouchStart);
     this.scrollBarElement.removeEventListener('touchmove', this.boundTouchMove);
     this.scrollBarElement.removeEventListener('touchend', this.boundTouchEnd);
   }
 
+  /**
+   * タッチ開始時の指の位置とスクロールバー位置を記録し、move での差分計算の基点にする。
+   */
   private handleTouchStart(e: TouchEvent): void {
     e.preventDefault();
     this.isTouchDragging = true;
@@ -158,6 +190,9 @@ export class DragManager {
     this.onVisualStateChange(true);
   }
 
+  /**
+   * 開始位置との差分を加算してスクロールバーを指に追従させる。
+   */
   private handleTouchMove(e: TouchEvent): void {
     if (!this.isTouchDragging) return;
     e.preventDefault();
@@ -168,6 +203,9 @@ export class DragManager {
     this.onDragCallback(this.constrainPositionWithinBounds(newTop));
   }
 
+  /**
+   * タッチ終了でドラッグフラグをクリアし、視覚状態をドラッグ解除に戻す。
+   */
   private handleTouchEnd(e: TouchEvent): void {
     if (!this.isTouchDragging) return;
     e.preventDefault();
@@ -180,6 +218,9 @@ export class DragManager {
   // 座標管理
   // ================================================================
 
+  /**
+   * style.top は文字列で格納されているため数値化して返す。未設定なら 0 とする。
+   */
   private getCurrentScrollBarTop(): number {
     return parseInt(this.scrollBarElement.style.top) || 0;
   }
@@ -196,6 +237,9 @@ export class DragManager {
   // 状態リセット
   // ================================================================
 
+  /**
+   * destroy 時に中途半端なドラッグ状態が残らないよう全フィールドを初期値に戻す。
+   */
   private resetState(): void {
     if (this.mouseDragState) {
       this.mouseDragState.isDragging = false;

--- a/app/frontend/src/components/Results/scroll/ScrollBarRenderer.ts
+++ b/app/frontend/src/components/Results/scroll/ScrollBarRenderer.ts
@@ -1,31 +1,33 @@
 import type { ScrollBarCalculation } from '../../../types';
 
+// ドラッグ状態の自動解除までの待機時間（ms）
 const RELEASE_DURATION = 2000;
 
 /**
- * Class responsible for DOM manipulation and rendering of scrollbars
+ * スクロールバーの DOM 操作と描画を担うクラス。
+ * 座標計算は scrollCalculator に委譲し、このクラスはスタイル適用とクラス操作のみを行う。
  */
 export class ScrollBarRenderer {
-  // Constants
+  // CSS クラス定数
   private static readonly CLASS_CURSOR_GRAB = 'grab';
   private static readonly CLASS_CURSOR_GRABBING = 'grabbing';
-
   private static readonly CLASS_ACTIVE = '-active';
   private static readonly CLASS_DRAGGING = '-dragging';
   private static readonly CLASS_DISABLED = '-disabled';
-
   private static readonly CLASS_BAR = 'bar';
   private static readonly CLASS_POSITION = 'position';
   private static readonly CLASS_TOTAL = 'total';
 
-  // Instance Properties
-  private _releaseTimeoutId: number | undefined;
+  private readonly container: HTMLElement;
+  private readonly scrollBarElement: HTMLElement;
+  private readonly positionLabel: HTMLElement;
+  private readonly totalLabel: HTMLElement;
 
-  // DOM elements
-  private readonly _container: HTMLElement;
-  private readonly _scrollBarElement: HTMLElement;
-  private readonly _positionLabel: HTMLElement;
-  private readonly _totalLabel: HTMLElement;
+  // 同じ値での DOM 更新を避けるためのキャッシュ
+  private lastPositionValue = -1;
+  private lastTotalValue = -1;
+
+  private releaseTimeoutId: number | undefined;
 
   constructor(
     container: HTMLElement,
@@ -33,39 +35,30 @@ export class ScrollBarRenderer {
     positionLabel: HTMLElement,
     totalLabel: HTMLElement
   ) {
-    this._container = container;
-    this._scrollBarElement = scrollBarElement;
-    this._positionLabel = positionLabel;
-    this._totalLabel = totalLabel;
+    this.container = container;
+    this.scrollBarElement = scrollBarElement;
+    this.positionLabel = positionLabel;
+    this.totalLabel = totalLabel;
   }
 
-  // ========================================
-  // DOM Initialization
-  // ========================================
+  // ================================================================
+  // DOM 初期化（static）
+  // ================================================================
 
-  /**
-   * Create and inject HTML structure for scrollbar into container
-   * @param container - Container element where scrollbar HTML will be inserted
-   */
+  /** スクロールバーの HTML 構造をコンテナへ挿入する。 */
   static createScrollBarHTML(container: HTMLElement): void {
     container.insertAdjacentHTML(
       'beforeend',
-      `
-      <div class="${ScrollBarRenderer.CLASS_BAR}">
+      `<div class="${ScrollBarRenderer.CLASS_BAR}">
         <div class="indicator">
           <span class="${ScrollBarRenderer.CLASS_POSITION}">1</span>
           <span class="${ScrollBarRenderer.CLASS_TOTAL}"></span>
         </div>
-      </div>
-      `
+      </div>`
     );
   }
 
-  /**
-   * Initialize and validate required DOM elements from container
-   * @param container - Container element containing the scrollbar structure
-   * @returns Object containing validated scrollbar DOM elements
-   */
+  /** コンテナからスクロールバーに必要な DOM 要素を取得して返す。 */
   static initializeElements(container: HTMLElement) {
     const scrollBar = container.querySelector(
       `.${ScrollBarRenderer.CLASS_BAR}`
@@ -80,177 +73,145 @@ export class ScrollBarRenderer {
     return { scrollBar, position, total };
   }
 
-  // ========================================
-  // Label Update
-  // ========================================
+  // ================================================================
+  // ラベル更新
+  // ================================================================
 
   /**
-   * Update position label display
-   * @param offset - Offset value
+   * 現在位置ラベルを更新する。
+   * 値が変わっていない場合は DOM を触らずスキップし、不要なレイアウト再計算を防ぐ。
    */
   updatePositionLabel(offset: number): void {
-    this._positionLabel.textContent = String(offset + 1);
+    const value = offset + 1;
+    if (value === this.lastPositionValue) return;
+    this.lastPositionValue = value;
+    this.positionLabel.textContent = String(value);
   }
 
   /**
-   * Update total label
-   * @param numberOfRecords - Total number of records
+   * 総件数ラベルを更新する。
+   * 値が変わっていない場合は DOM を触らずスキップし、不要なレイアウト再計算を防ぐ。
    */
   updateTotalLabel(numberOfRecords: number): void {
-    this._totalLabel.textContent = numberOfRecords.toLocaleString();
+    if (numberOfRecords === this.lastTotalValue) return;
+    this.lastTotalValue = numberOfRecords;
+    this.totalLabel.textContent = numberOfRecords.toLocaleString();
   }
 
-  // ========================================
-  // Position & Size Styling
-  // ========================================
+  // ================================================================
+  // 位置・サイズのスタイル適用
+  // ================================================================
 
   /**
-   * Apply scrollbar styles with calculation results
-   * @param calculation - Calculation results
-   * @param offset - Offset value
+   * タッチスクロール中のリアルタイムフィードバック用にスクロールバーを更新する。
+   * active クラスと position ラベルも同時に反映する。
    */
-  applyScrollBarStyles(
-    calculation: ScrollBarCalculation,
-    offset: number
-  ): void {
-    // Apply bar styles
-    this._scrollBarElement.style.height = `${calculation.barHeight}px`;
-    this._scrollBarElement.style.top = `${calculation.barTop}px`;
-
-    // Update position display
+  applyScrollBarStyles(calculation: ScrollBarCalculation, offset: number): void {
+    this.scrollBarElement.style.height = `${calculation.barHeight}px`;
+    this.scrollBarElement.style.top = `${calculation.barTop}px`;
     this.updatePositionLabel(offset);
-
-    // Maintain active state
-    this._container.classList.add(ScrollBarRenderer.CLASS_ACTIVE);
+    this.container.classList.add(ScrollBarRenderer.CLASS_ACTIVE);
   }
 
   /**
-   * Update scrollbar visual state and disabled status
-   * @param calculation - Calculation results
-   * @param rowCount - Number of visible rows
-   * @param numberOfRecords - Total number of records
+   * Store の値変化（offset・件数・行数）に応じてスクロールバーを同期する。
+   * ドラッグ状態を起動してラベルを表示し、スクロール停止後 RELEASE_DURATION で自動解除する。
    */
   updateScrollBarVisualState(
     calculation: ScrollBarCalculation,
     rowCount: number,
     numberOfRecords: number
   ): void {
-    this._scrollBarElement.style.height = `${calculation.barHeight}px`;
-    this._scrollBarElement.style.top = `${calculation.barTop}px`;
+    this.scrollBarElement.style.height = `${calculation.barHeight}px`;
+    this.scrollBarElement.style.top = `${calculation.barTop}px`;
 
-    // Show dragging state when scrollbar updates due to data changes
-    // This provides visual feedback that the scrollbar position/size changed
-    // Auto-release ensures the feedback disappears after users have time to notice
     this.activateDragStateWithAutoRelease();
 
     if (rowCount === 0 || numberOfRecords === rowCount) {
-      this._scrollBarElement.classList.add(ScrollBarRenderer.CLASS_DISABLED);
+      this.scrollBarElement.classList.add(ScrollBarRenderer.CLASS_DISABLED);
     } else {
-      this._scrollBarElement.classList.remove(ScrollBarRenderer.CLASS_DISABLED);
+      this.scrollBarElement.classList.remove(ScrollBarRenderer.CLASS_DISABLED);
     }
   }
 
-  /**
-   * Update scrollbar position (top style)
-   * @param top - Top position in pixels
-   */
+  /** スクロールバーの top 位置だけを更新する（ドラッグ中の位置追従用）。 */
   updateScrollBarPosition(top: number): void {
-    this._scrollBarElement.style.top = `${top}px`;
+    this.scrollBarElement.style.top = `${top}px`;
   }
 
-  // ========================================
-  // Active State Management
-  // ========================================
+  // ================================================================
+  // active 状態管理
+  // ================================================================
 
-  /**
-   * Set scrollbar as active
-   */
+  /** スクロールバーを active 状態にする（タッチスクロール開始時）。 */
   setActive(): void {
-    this._container.classList.add(ScrollBarRenderer.CLASS_ACTIVE);
+    this.container.classList.add(ScrollBarRenderer.CLASS_ACTIVE);
   }
 
-  /**
-   * Set scrollbar as inactive
-   */
+  /** スクロールバーの active 状態を解除する（タッチスクロール終了時）。 */
   setInactive(): void {
-    this._container.classList.remove(ScrollBarRenderer.CLASS_ACTIVE);
+    this.container.classList.remove(ScrollBarRenderer.CLASS_ACTIVE);
   }
 
-  // ========================================
-  // Drag State Management
-  // ========================================
+  // ================================================================
+  // ドラッグ状態管理
+  // ================================================================
 
   /**
-   * Update dragging state
-   * @param isDragging - Whether currently dragging
+   * ドラッグの開始・終了に応じてスクロールバーの見た目を切り替える。
+   * 終了時は一定時間後に自動解除して視覚フィードバックを残す。
    */
   updateDraggingState(isDragging: boolean): void {
     if (isDragging) {
-      // User started dragging: immediately show dragging state
-      this._container.classList.add(ScrollBarRenderer.CLASS_DRAGGING);
-      this._container.classList.add(ScrollBarRenderer.CLASS_ACTIVE);
+      this.container.classList.add(ScrollBarRenderer.CLASS_DRAGGING);
+      this.container.classList.add(ScrollBarRenderer.CLASS_ACTIVE);
     } else {
-      // User stopped dragging: use auto-release to provide visual feedback
       this.activateDragStateWithAutoRelease();
     }
   }
 
   /**
-   * Activate dragging visual state and schedule its automatic release
-   * Sets the dragging state immediately and schedules removal after delay
+   * ドラッグ状態を即座に表示し、RELEASE_DURATION 後に自動解除する。
+   * 既存タイマーはリセットして多重起動を防ぐ。
    */
   activateDragStateWithAutoRelease(): void {
-    // Clear any existing timeout to prevent multiple timers running simultaneously
-    if (this._releaseTimeoutId !== undefined) {
-      window.clearTimeout(this._releaseTimeoutId);
+    if (this.releaseTimeoutId !== undefined) {
+      window.clearTimeout(this.releaseTimeoutId);
     }
 
-    // Immediately show dragging state for instant visual feedback
-    // This must happen before setTimeout to ensure users see immediate response
-    this._container.classList.add(ScrollBarRenderer.CLASS_DRAGGING);
+    this.container.classList.add(ScrollBarRenderer.CLASS_DRAGGING);
 
-    // Schedule automatic removal of dragging state after delay
-    // This provides visual feedback time for users to notice the change
-    // while ensuring the UI returns to normal state automatically
-    this._releaseTimeoutId = window.setTimeout(() => {
-      // Remove dragging state to return scrollbar to normal visual appearance
-      this._container.classList.remove(ScrollBarRenderer.CLASS_DRAGGING);
-      // Clear the timeout ID after execution to maintain clean state
-      this._releaseTimeoutId = undefined;
+    this.releaseTimeoutId = window.setTimeout(() => {
+      this.container.classList.remove(ScrollBarRenderer.CLASS_DRAGGING);
+      this.releaseTimeoutId = undefined;
     }, RELEASE_DURATION);
   }
 
-  /**
-   * Update cursor style for drag operations
-   * @param isDragging - Whether currently dragging
-   */
+  // ================================================================
+  // カーソルスタイル
+  // ================================================================
+
+  /** ドラッグ中かどうかに応じてカーソルを grabbing / grab に切り替える。 */
   updateCursorStyle(isDragging: boolean): void {
-    this._scrollBarElement.style.cursor = isDragging
+    this.scrollBarElement.style.cursor = isDragging
       ? ScrollBarRenderer.CLASS_CURSOR_GRABBING
       : ScrollBarRenderer.CLASS_CURSOR_GRAB;
   }
 
-  /**
-   * Reset cursor style to default
-   */
+  /** カーソルを grab（初期状態）にリセットする。 */
   resetCursorStyle(): void {
-    this._scrollBarElement.style.cursor = ScrollBarRenderer.CLASS_CURSOR_GRAB;
+    this.scrollBarElement.style.cursor = ScrollBarRenderer.CLASS_CURSOR_GRAB;
   }
 
-  // ========================================
-  // Cleanup
-  // ========================================
+  // ================================================================
+  // クリーンアップ
+  // ================================================================
 
-  /**
-   * Clean up all timeouts and timers
-   * Call this method when the renderer is no longer needed
-   */
+  /** 実行中のタイマーをすべてキャンセルする。コンポーネント破棄時に必ず呼ぶこと。 */
   clearAllTimeouts(): void {
-    if (this._releaseTimeoutId !== undefined) {
-      window.clearTimeout(this._releaseTimeoutId);
-      // CRITICAL: Reset to undefined to prevent memory leaks and state confusion
-      // Without this, the timeout ID remains in memory and state checks become unreliable
-      this._releaseTimeoutId = undefined;
+    if (this.releaseTimeoutId !== undefined) {
+      window.clearTimeout(this.releaseTimeoutId);
+      this.releaseTimeoutId = undefined;
     }
   }
 }

--- a/app/frontend/src/components/Results/scroll/scrollCalculator.ts
+++ b/app/frontend/src/components/Results/scroll/scrollCalculator.ts
@@ -8,20 +8,13 @@ import type {
 const MIN_SCROLLBAR_HEIGHT = 30;
 
 /**
- * Collection of pure calculation functions for scroll-related operations.
- * These functions handle scroll position calculations, offset conversions,
- * and scrollbar visual positioning without any side effects.
+ * スクロール関連の純粋計算関数群。
+ * 副作用なしで座標計算・offset変換・スクロールバーの表示位置を算出する。
  */
 
 /**
- * Calculates new scroll position based on wheel/trackpad input.
- * Handles boundary checking to prevent scrolling beyond valid range.
- *
- * @param deltaY - The Y-axis movement delta from scroll events
- * @param currentScrollPosition - Current pixel scroll position
- * @param totalRecordCount - Total number of records in the dataset
- * @param visibleRowCount - Number of rows visible in the viewport
- * @returns Object containing calculated scroll values and constraints
+ * ホイール・トラックパッド入力からの新しいスクロール位置を計算する。
+ * 有効範囲外へのスクロールを防ぐ境界チェックを含む。
  */
 export function calculateNewScrollPosition(
   deltaY: number,
@@ -30,8 +23,10 @@ export function calculateNewScrollPosition(
   visibleRowCount: number
 ): ScrollCalculation {
   const totalContentHeight = totalRecordCount * TR_HEIGHT;
-  let maxScrollableDistance = totalContentHeight - visibleRowCount * TR_HEIGHT;
-  maxScrollableDistance = Math.max(0, maxScrollableDistance);
+  const maxScrollableDistance = Math.max(
+    0,
+    totalContentHeight - visibleRowCount * TR_HEIGHT
+  );
 
   const newScrollPosition = clampValueWithinBounds(
     currentScrollPosition + deltaY,
@@ -46,12 +41,7 @@ export function calculateNewScrollPosition(
 }
 
 /**
- * Constrains a numeric value within specified minimum and maximum bounds.
- * Essential for preventing scroll positions from exceeding valid ranges.
- *
- * @param value - The value to constrain
- * @param bounds - Object containing min and max boundary values
- * @returns The value clamped within the specified bounds
+ * 数値を指定した最小値・最大値の範囲内に収める。
  */
 export function clampValueWithinBounds(
   value: number,
@@ -61,11 +51,8 @@ export function clampValueWithinBounds(
 }
 
 /**
- * Converts pixel-based scroll position to row-based offset.
- * Used to determine which row should be at the top of the viewport.
- *
- * @param scrollPosition - Current scroll position in pixels
- * @returns Row offset (0-based index of the first visible row)
+ * ピクセル単位のスクロール位置を行単位の offset に変換する。
+ * ビューポート先頭に表示すべき行のインデックスを返す。
  */
 export function convertScrollPositionToRowOffset(
   scrollPosition: number
@@ -74,56 +61,34 @@ export function convertScrollPositionToRowOffset(
 }
 
 /**
- * Calculates row offset for touch-based scrolling interactions.
- * Touch scrolling uses proportional movement relative to available space.
- *
- * @param deltaY - Y-axis movement delta from touch events
- * @param touchStartOffset - Row offset when touch interaction began
- * @param visibleRowCount - Number of rows visible in the viewport
- * @param totalRecordCount - Total number of records in the dataset
- * @returns Calculated row offset for the new scroll position
+ * タッチスクロールの行 offset を計算する。
+ * 27px（TR_HEIGHT）のスワイプ = 1行という1:1の自然なスクロール感を実現する。
+ * deltaY はタッチ開始からの累積ピクセル量、touchStartOffset はタッチ開始時に
+ * 一度だけ取得した固定値を渡すこと（ジェスチャー中に変えると誤差が積み上がる）。
  */
 export function calculateTouchBasedRowOffset(
   deltaY: number,
-  touchStartOffset: number,
-  visibleRowCount: number,
-  totalRecordCount: number
+  touchStartOffset: number
 ): number {
-  const viewportHeight = visibleRowCount * TR_HEIGHT;
-  const movementRatio = deltaY / viewportHeight;
-
-  return Math.ceil(movementRatio * totalRecordCount) + touchStartOffset;
+  return Math.round(deltaY / TR_HEIGHT) + touchStartOffset;
 }
 
 /**
- * Ensures row offset stays within valid boundaries.
- * Prevents scrolling beyond the first or last available rows.
- *
- * @param offset - Row offset to validate and constrain
- * @param visibleRowCount - Number of rows visible in the viewport
- * @param totalRecordCount - Total number of records in the dataset
- * @returns Constrained offset within valid range [0, maxOffset]
+ * 行 offset を有効範囲 [0, totalRecordCount - visibleRowCount] に収める。
+ * 先頭・末尾を超えたスクロールを防ぐ。
  */
 export function constrainRowOffsetToValidRange(
   offset: number,
   visibleRowCount: number,
   totalRecordCount: number
 ): number {
-  const minOffset = 0;
   const maxOffset = Math.max(0, totalRecordCount - visibleRowCount);
-
-  return Math.max(minOffset, Math.min(offset, maxOffset));
+  return Math.max(0, Math.min(offset, maxOffset));
 }
 
 /**
- * Calculates scrollbar visual properties based on current scroll state.
- * Determines the scrollbar's height, position, and display ratio for proper rendering.
- * Ensures minimum scrollbar height for usability regardless of content size.
- *
- * @param currentRowOffset - Current row offset (first visible row index)
- * @param visibleRowCount - Number of rows visible in the viewport
- * @param totalRecordCount - Total number of records in the dataset
- * @returns Object containing scrollbar height, position, and display ratio
+ * 現在のスクロール状態からスクロールバーの表示プロパティを計算する。
+ * コンテンツ量に関わらず最低高さ（MIN_SCROLLBAR_HEIGHT）を保証する。
  */
 export function calculateScrollbarDimensions(
   currentRowOffset: number,
@@ -134,11 +99,11 @@ export function calculateScrollbarDimensions(
   const viewportHeight = visibleRowCount * TR_HEIGHT;
   const visibilityRatio = viewportHeight / totalContentHeight;
 
-  // Calculate scrollbar height with minimum constraint
-  let scrollbarHeight = Math.ceil(viewportHeight * visibilityRatio);
-  scrollbarHeight = Math.max(scrollbarHeight, MIN_SCROLLBAR_HEIGHT);
+  const scrollbarHeight = Math.max(
+    Math.ceil(viewportHeight * visibilityRatio),
+    MIN_SCROLLBAR_HEIGHT
+  );
 
-  // Calculate scrollbar position within available space
   const availableScrollSpace = viewportHeight - scrollbarHeight;
   const positionRatio = availableScrollSpace / totalContentHeight;
   const scrollbarTopPosition = Math.ceil(

--- a/app/frontend/src/store/StoreManager.ts
+++ b/app/frontend/src/store/StoreManager.ts
@@ -289,16 +289,16 @@ class StoreManager {
    * isSearchResultsUpdating中は中途状態を返さないようloadingを返す。
    * データが未取得（null）の場合は 'loading' を返すだけで fetch は起動しない。
    * fetch のトリガーは呼び出し元が searchManager.requestNextPage() 経由で行う。
+   * スクロール中に全表示行で呼ばれるため、結果レコードはcloneせず読み取り専用として返す。
    */
   getRecordByIndex(index: number): SearchRecordLookupResult {
     if (this.getData('isSearchResultsUpdating')) return 'loading';
-    const result = getSearchRecordByDisplayIndex(
+    return getSearchRecordByDisplayIndex(
       this.state.searchResults,
       index,
       this.state.offset,
       this.state.numberOfRecords
     );
-    return typeof result === 'string' ? result : this.deepCopy(result);
   }
 
   /**

--- a/app/frontend/src/types/components.d.ts
+++ b/app/frontend/src/types/components.d.ts
@@ -95,10 +95,7 @@ export interface TouchState {
   startY: number;
   startX: number;
   startTime: number;
-  lastY: number;
-  lastX: number;
   distance: number;
-  duration: number;
   isScrolling: boolean;
 }
 


### PR DESCRIPTION
resultsディレクトリのリファクタリングを行いました。

calculateTouchBasedRowOffset の計算式を viewport比率 × totalRecords からピクセルベース（deltaY / TR_HEIGHT）に変更。旧ロジックは totalRecordCount に比例してジャンプ幅が拡大するバグがあり、スクロール操作でランダムな行飛びが発生していた。

This pull request focuses on improving code readability and maintainability in the results table column resizing and auto-sizing logic. The main changes involve renaming private class members and methods to follow a more consistent and modern naming convention, primarily by removing leading underscores. 
Key refactoring changes:

**ResultsColumnAutoSizer class (`ResultsColumnAutoSizer.ts`):**
- Renamed all private fields and methods to remove leading underscores and use camelCase (e.g., `_tbody` → `tbody`, `_measureColumnContentWidth` → `measureColumnContentWidth`). [[1]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L17-R42) [[2]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L70-R55) [[3]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L84-R92) [[4]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L120-R136) [[5]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L178-R156) [[6]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L200-R171) [[7]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L212-R208) [[8]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L258-R220) [[9]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L284-R246) [[10]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L308-R280) [[11]](diffhunk://#diff-3c18b209094334a983af1a7bec62f29fff9759fb50e921d8b79519b81d538327L345-R297)

**ResultsColumnResizeController class (`ResultsColumnResizeController.ts`):**
- Renamed all private fields and methods to remove leading underscores and use camelCase (e.g., `_thead` → `thead`, `_attachEventHandlers` → `attachEventHandlers`).

These changes streamline the codebase, making it easier to read and maintain, without impacting any application behavior.