### PR TITLE
Bugfix/checkbox

### DIFF
--- a/app/frontend/src/auth/authService.ts
+++ b/app/frontend/src/auth/authService.ts
@@ -13,7 +13,7 @@ export async function fetchLoginStatus(): Promise<void> {
       return;
     }
 
-    if (window.location.origin === 'http://localhost:8000') {
+    if (isLocalDevelopmentHost(window.location.hostname)) {
       // ?auth=login でログイン時UIを確認できるようにする。
       const localAuthPreview = new URLSearchParams(window.location.search).get(
         'auth'
@@ -49,4 +49,11 @@ export async function fetchLoginStatus(): Promise<void> {
     }
     storeManager.setData('isLogin', false);
   }
+}
+
+/**
+ * localでは実認証を行わないため、ポートに依存せず開発用ログインプレビューを有効にする。
+ */
+function isLocalDevelopmentHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
 }

--- a/app/frontend/src/auth/authService.ts
+++ b/app/frontend/src/auth/authService.ts
@@ -41,10 +41,7 @@ export async function fetchLoginStatus(): Promise<void> {
       }
     }
   } catch (error) {
-    if (
-      window.location.hostname === 'localhost' ||
-      window.location.hostname === '127.0.0.1'
-    ) {
+    if (isLocalDevelopmentHost(window.location.hostname)) {
       console.warn('Failed to fetch auth status:', error);
     }
     storeManager.setData('isLogin', false);

--- a/app/frontend/src/auth/authService.ts
+++ b/app/frontend/src/auth/authService.ts
@@ -14,7 +14,11 @@ export async function fetchLoginStatus(): Promise<void> {
     }
 
     if (window.location.origin === 'http://localhost:8000') {
-      storeManager.setData('isLogin', false);
+      // ?auth=login でログイン時UIを確認できるようにする。
+      const localAuthPreview = new URLSearchParams(window.location.search).get(
+        'auth'
+      );
+      storeManager.setData('isLogin', localAuthPreview === 'login');
       return;
     }
 

--- a/app/frontend/src/components/Condition/ConditionValueEditor/ConditionValueEditorDatasetColumns.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/ConditionValueEditorDatasetColumns.ts
@@ -10,6 +10,7 @@ import { DatasetColumnRenderer } from './dataset-columns/DatasetColumnRenderer';
 import { DatasetColumnEventHandler } from './dataset-columns/DatasetColumnEventHandler';
 import { DatasetCheckStateManager } from './dataset-columns/DatasetCheckStateManager';
 import { DatasetValueViewManager } from './dataset-columns/DatasetValueViewManager';
+import { isDatasetLockedForAnonymousUser } from './dataset-columns/datasetAccess';
 import type { UiNode } from './dataset-columns/types';
 import { createEl } from '../../../utils/dom/createEl';
 import { selectRequired } from '../../../utils/dom/select';
@@ -105,6 +106,7 @@ export class ConditionValueEditorDatasetColumns extends ConditionValueEditor {
    * 子孫・祖先の状態も同時に再計算することで、部分選択（indeterminate）を正しく復元する。
    */
   restore(): void {
+    const userIsLoggedIn = storeManager.getData('isLogin');
     this._dataProcessor.resetAllCheckStates(this._data);
     this._dataProcessor.restoreCheckedStates(
       this._data,
@@ -113,10 +115,11 @@ export class ConditionValueEditorDatasetColumns extends ConditionValueEditor {
         this._checkStateManager.updateChildrenCheckState(
           node,
           checked,
-          storeManager.getData('isLogin')
+          userIsLoggedIn
         ),
       (node, checked) =>
-        this._checkStateManager.updateParentCheckState(node, checked)
+        this._checkStateManager.updateParentCheckState(node, checked),
+      (node) => !isDatasetLockedForAnonymousUser(node.data, userIsLoggedIn)
     );
     this._updateUI();
   }
@@ -136,7 +139,10 @@ export class ConditionValueEditorDatasetColumns extends ConditionValueEditor {
    */
   private _initializeUI(): void {
     this.createSectionEl('columns-editor-view', () => [
-      createEl('header', { class: 'section-header', text: `Select ${this.conditionType}` }),
+      createEl('header', {
+        class: 'section-header',
+        text: `Select ${this.conditionType}`,
+      }),
       createEl('div', {
         class: 'section-content',
         children: [createEl('div', { class: 'columns' })],

--- a/app/frontend/src/components/Condition/ConditionValueEditor/ConditionValueEditorDatasetColumns.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/ConditionValueEditorDatasetColumns.ts
@@ -110,7 +110,11 @@ export class ConditionValueEditorDatasetColumns extends ConditionValueEditor {
       this._data,
       this._lastValueViews,
       (node, checked) =>
-        this._checkStateManager.updateChildrenCheckState(node, checked),
+        this._checkStateManager.updateChildrenCheckState(
+          node,
+          checked,
+          storeManager.getData('isLogin')
+        ),
       (node, checked) =>
         this._checkStateManager.updateParentCheckState(node, checked)
     );
@@ -237,7 +241,11 @@ export class ConditionValueEditorDatasetColumns extends ConditionValueEditor {
       column,
       this._data,
       (node, checked) =>
-        this._checkStateManager.updateChildrenCheckState(node, checked),
+        this._checkStateManager.updateChildrenCheckState(
+          node,
+          checked,
+          userIsLoggedIn
+        ),
       (node, checked) =>
         this._checkStateManager.updateParentCheckState(node, checked),
       () => {

--- a/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetCheckStateManager.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetCheckStateManager.ts
@@ -1,5 +1,6 @@
 import type { HierarchyNode } from 'd3-hierarchy';
 import type { UiNode } from './types';
+import { isDatasetLockedForAnonymousUser } from './datasetAccess';
 
 /**
  * チェックボックス選択状態の親子間整合性を管理する。
@@ -11,11 +12,18 @@ export class DatasetCheckStateManager {
   /** 親ノードのチェック状態を全子孫へ伝播させる。 */
   updateChildrenCheckState(
     parentNode: HierarchyNode<UiNode>,
-    isSelected: boolean
+    isSelected: boolean,
+    userIsLoggedIn: boolean
   ): void {
     if (!parentNode.children || parentNode.children.length === 0) return;
 
     parentNode.descendants().forEach((descendant) => {
+      if (isDatasetLockedForAnonymousUser(descendant.data, userIsLoggedIn)) {
+        descendant.data.checked = false;
+        descendant.data.indeterminate = false;
+        return;
+      }
+
       descendant.data.checked = isSelected;
       descendant.data.indeterminate = false;
     });

--- a/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetColumnEventHandler.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetColumnEventHandler.ts
@@ -23,13 +23,12 @@ export class DatasetColumnEventHandler {
     ) => void,
     updateParentStates: (
       node: HierarchyNode<UiNode>,
-      isSelected: boolean
+      isSelected?: boolean
     ) => void,
     refreshUserInterface: () => void
   ): void {
     columnElement.addEventListener('change', (event) => {
       const clickedCheckbox = event.target as HTMLInputElement;
-      const isNowSelected = clickedCheckbox.checked;
       const listItemElement = clickedCheckbox.closest('li');
       if (!listItemElement || !listItemElement.dataset.id) return;
 
@@ -39,16 +38,36 @@ export class DatasetColumnEventHandler {
       );
       if (!clickedDatasetNode) return;
 
-      if (clickedDatasetNode.children) {
-        propagateToChildren(clickedDatasetNode, isNowSelected);
-      }
+      const nextSelectionState = this.getNextSelectionState(
+        clickedDatasetNode,
+        clickedCheckbox
+      );
 
-      if (clickedDatasetNode.parent) {
-        updateParentStates(clickedDatasetNode, isNowSelected);
+      if (clickedDatasetNode.children) {
+        propagateToChildren(clickedDatasetNode, nextSelectionState);
+        updateParentStates(clickedDatasetNode);
+      } else if (clickedDatasetNode.parent) {
+        updateParentStates(clickedDatasetNode, nextSelectionState);
       }
 
       refreshUserInterface();
     });
+  }
+
+  /**
+   * ロックされた子を含む親はindeterminateになり得るため、親だけはDOMではなくデータ状態から次の選択を決める。
+   */
+  private getNextSelectionState(
+    clickedDatasetNode: HierarchyNode<UiNode>,
+    clickedCheckbox: HTMLInputElement
+  ): boolean {
+    if (!clickedDatasetNode.children) {
+      return clickedCheckbox.checked;
+    }
+
+    return !(
+      clickedDatasetNode.data.checked || clickedDatasetNode.data.indeterminate
+    );
   }
 
   /** カラムのarrow要素にクリックリスナーを登録する。 */

--- a/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetColumnRenderer.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetColumnRenderer.ts
@@ -3,8 +3,7 @@ import { createEl } from '../../../../utils/dom/createEl';
 import { ADVANCED_CONDITION_TYPE } from '../../../../advancedCondition';
 import { fetchLoginStatus } from '../../../../auth/authService';
 import type { UiNode } from './types';
-
-const PUBLIC_JGA_WGS_DATASETS = new Set(['jga_wgs.jgad000758', 'jga_wgs.jgad000868']);
+import { isDatasetLockedForAnonymousUser } from './datasetAccess';
 
 /**
  * データセットカラムUIのDOM要素を生成する。
@@ -151,11 +150,7 @@ export class DatasetColumnRenderer {
     datasetNode: HierarchyNode<UiNode>,
     userIsLoggedIn: boolean
   ): boolean {
-    return (
-      userIsLoggedIn === false &&
-      (datasetNode.data.value?.includes('jga_wgs.') ?? false) &&
-      !PUBLIC_JGA_WGS_DATASETS.has(datasetNode.data.value ?? '')
-    );
+    return isDatasetLockedForAnonymousUser(datasetNode.data, userIsLoggedIn);
   }
 
   /**

--- a/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetTreeDataProcessor.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/DatasetTreeDataProcessor.ts
@@ -87,6 +87,7 @@ export class DatasetTreeDataProcessor {
   /**
    * 保存済みの選択値をツリーへ復元する。
    * キャンセル時に編集前の状態へ戻すために使う。
+   * canRestoreSelectionで認証状態に合わない保存値を除外し、匿名ユーザーにロック対象が混入しないようにする。
    */
   restoreCheckedStates(
     datasetTree: HierarchyNode<UiNode>,
@@ -97,18 +98,23 @@ export class DatasetTreeDataProcessor {
     ) => void,
     updateParentStates: (
       node: HierarchyNode<UiNode>,
-      isSelected: boolean
-    ) => void
+      isSelected?: boolean
+    ) => void,
+    canRestoreSelection: (node: HierarchyNode<UiNode>) => boolean = () => true
   ): void {
     for (const savedSelection of savedSelections) {
       const nodeToRestore = datasetTree.find(
         (datasetNode) => datasetNode.data.value === savedSelection.value
       );
       if (!nodeToRestore) continue;
+      if (!canRestoreSelection(nodeToRestore)) continue;
 
       nodeToRestore.data.checked = true;
       propagateToChildren(nodeToRestore, true);
-      updateParentStates(nodeToRestore, true);
+      updateParentStates(
+        nodeToRestore,
+        nodeToRestore.children ? undefined : true
+      );
     }
   }
 }

--- a/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/datasetAccess.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/datasetAccess.ts
@@ -1,0 +1,22 @@
+import type { UiNode } from './types';
+
+// JGA-WGSのdataset定義を更新したときは、この未ログイン選択可能リストも必ず見直す。
+// 将来的にマスターJSONへ requires_login のような属性を持たせた場合は、この手書きリストを廃止する。
+export const PUBLIC_JGA_WGS_DATASETS = new Set([
+  'jga_wgs.jgad000758',
+  'jga_wgs.jgad000868',
+]);
+
+/**
+ * 未ログイン時にJGAD制限データセットを選択状態へ含めないため、表示と状態更新で同じ判定を使う。
+ */
+export function isDatasetLockedForAnonymousUser(
+  datasetNode: Pick<UiNode, 'value'>,
+  userIsLoggedIn: boolean
+): boolean {
+  return (
+    userIsLoggedIn === false &&
+    (datasetNode.value?.includes('jga_wgs.') ?? false) &&
+    !PUBLIC_JGA_WGS_DATASETS.has(datasetNode.value ?? '')
+  );
+}

--- a/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/datasetAccess.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/dataset-columns/datasetAccess.ts
@@ -16,7 +16,7 @@ export function isDatasetLockedForAnonymousUser(
 ): boolean {
   return (
     userIsLoggedIn === false &&
-    (datasetNode.value?.includes('jga_wgs.') ?? false) &&
+    (datasetNode.value?.startsWith('jga_wgs.') ?? false) &&
     !PUBLIC_JGA_WGS_DATASETS.has(datasetNode.value ?? '')
   );
 }

--- a/app/frontend/views/layouts/application.pug
+++ b/app/frontend/views/layouts/application.pug
@@ -62,18 +62,21 @@ html(data-page=locals.currentPage, lang=lang)
             window.location.hostname === '127.0.0.1' ||
             window.location.hostname === '::1'
           ) {
-            // localでは実認証を行わないが、UI確認のため ?auth=login でLogout表示を再現できるようにする。
+            // localでは実認証を行わないため、Login/Logoutクリックで ?auth=login を切り替えて認証UIを確認できるようにする。
             const localAuthPreview = new URLSearchParams(window.location.search).get('auth');
             const localIsLogin = localAuthPreview === 'login';
             const localLabel = localIsLogin ? "Logout" : "Login";
-            loginMenu.href = '#';
-            loginMenu.setAttribute('aria-disabled', 'true');
-            loginMenu.setAttribute('tabindex', '-1');
+            const localAuthUrl = new URL(window.location.href);
+            if (localIsLogin) {
+              localAuthUrl.searchParams.delete('auth');
+            } else {
+              localAuthUrl.searchParams.set('auth', 'login');
+            }
+            loginMenu.href = localAuthUrl.toString();
+            loginMenu.removeAttribute('aria-disabled');
+            loginMenu.removeAttribute('tabindex');
             loginMenu.setAttribute('aria-label', localLabel);
             loginMenu.textContent = localLabel;
-            loginMenu.addEventListener('click', function(event) {
-              event.preventDefault();
-            });
             return;
           }
 


### PR DESCRIPTION
[#330](https://github.com/togovar/meeting/issues/330)
datasetのチェックボックスの挙動の変更を行いました。


This pull request improves how dataset selection is handled for anonymous (not logged-in) users, particularly restricting access to certain JGA-WGS datasets. It centralizes the logic for determining dataset accessibility, ensures consistent UI and state handling, and improves the local authentication preview for development.

**Dataset access control improvements:**

* Introduced a new utility (`datasetAccess.ts`) with a function `isDatasetLockedForAnonymousUser` and a public dataset allowlist to consistently determine if a dataset should be selectable by anonymous users.
* Updated `DatasetCheckStateManager` to prevent locked datasets from being selected or set to indeterminate state for anonymous users when propagating selection state changes. [[1]](diffhunk://#diff-5546b7bc84ef8a69411cdcb000a4e69d3493a7b8cb1cd5dbafbda967ff84fe0bR3) [[2]](diffhunk://#diff-5546b7bc84ef8a69411cdcb000a4e69d3493a7b8cb1cd5dbafbda967ff84fe0bL14-R26)
* Refactored `DatasetColumnRenderer` and related files to use the centralized access check, ensuring consistent UI disabling of restricted datasets. [[1]](diffhunk://#diff-ecb825c9d7eb8cbb669eee007bcf3e70eafa22946648dd617c390932f1d71f77L6-R6) [[2]](diffhunk://#diff-ecb825c9d7eb8cbb669eee007bcf3e70eafa22946648dd617c390932f1d71f77L154-R153)

**Selection state propagation and event handling:**

* Improved event handling in `DatasetColumnEventHandler` to correctly propagate selection and indeterminate states, especially when parent nodes include locked children, and refactored logic to support the new access control. [[1]](diffhunk://#diff-c7e8b746604751368b4f4afe1930361e4108e8606e0ae9dda98fa711d9c8cfe8L26-L32) [[2]](diffhunk://#diff-c7e8b746604751368b4f4afe1930361e4108e8606e0ae9dda98fa711d9c8cfe8L42-R72) [[3]](diffhunk://#diff-afac65cdc6c686dcb222fe7fd3a56e5c2d2cebd0fb0fed3733d83e45ceda61beL113-R117) [[4]](diffhunk://#diff-afac65cdc6c686dcb222fe7fd3a56e5c2d2cebd0fb0fed3733d83e45ceda61beL240-R248)

**Local authentication preview enhancements:**

* Enhanced the local development authentication preview so that clicking Login/Logout toggles the `?auth=login` parameter, making it easier to test authenticated/unauthenticated UI states. [[1]](diffhunk://#diff-3c18c1da2e0a9a73cf504244d10b6724833d30c2e410698aa7eda4328c5d0c44L17-R21) [[2]](diffhunk://#diff-cef096f8c53aef0e076ae73b2ac2dcd505ec90daba816c82b0a6d84d335beb30L65-L76)