### PR TITLE
fix: skip restore when frequency count mode is missing

### DIFF
--- a/app/frontend/src/components/Condition/ConditionValueEditor/ConditionValueEditorFrequencyCount.ts
+++ b/app/frontend/src/components/Condition/ConditionValueEditor/ConditionValueEditorFrequencyCount.ts
@@ -649,6 +649,7 @@ export class ConditionValueEditorFrequencyCount extends ConditionValueEditor {
     freqCountView: FrequencyCountValueView
   ): void {
     if (this._hasUserChangedCondition) return;
+    if (!freqCountView.dataset.mode) return;
 
     const mode = freqCountView.mode as ModeType;
     this._mode = mode;


### PR DESCRIPTION
[#336](https://github.com/togovar/meeting/issues/336)
Genotype countに関するバグを修正しました。

This pull request makes a minor update to the `ConditionValueEditorFrequencyCount` class to improve input validation. Specifically, it adds a guard clause to ensure that the `dataset.mode` property exists before proceeding, preventing potential errors if the property is missing.