### PR TITLE
Fix/style

### DIFF
--- a/app/frontend/assets/stanza.json
+++ b/app/frontend/assets/stanza.json
@@ -153,7 +153,7 @@
           "data-type": "json",
           "togostanza-custom_css_url": "https://togostanza.github.io/togostanza-themes/contrib/togovar.css?20260109",
           "page-size_option": "5,10,20,50,100",
-          "message-not_found": "No data.",
+          "message-not_found": "No data",
           "columns": [
             {
               "id": "species",

--- a/app/frontend/src/columns/index.ts
+++ b/app/frontend/src/columns/index.ts
@@ -200,7 +200,11 @@ export function usesInitialColumnWidth(columnId: string): boolean {
 }
 
 /** 固定列の追加時に判定箇所が分散しないよう、LOCKED_COLUMN_IDSを唯一の判定元にする。 */
-function isLockedColumnId(columnId: string): boolean {
+export function isLockedColumnId(columnId: string | undefined): boolean {
+  if (!columnId) {
+    return false;
+  }
+
   return LOCKED_COLUMN_IDS.includes(
     columnId as (typeof LOCKED_COLUMN_IDS)[number]
   );

--- a/app/frontend/src/components/Results/ResultsColumnsDropdown.ts
+++ b/app/frontend/src/components/Results/ResultsColumnsDropdown.ts
@@ -1,6 +1,6 @@
 import {
   getColumnLabel,
-  LOCKED_COLUMN_IDS,
+  isLockedColumnId,
   normalizeColumnConfigs,
 } from '../../columns';
 import { storeManager } from '../../store/StoreManager';
@@ -162,7 +162,7 @@ export class ResultsColumnsDropdown {
 
         const target = event.target;
         // 固定列はチェック状態の変更を無視
-        if (this.isLockedColumn(target.value)) {
+        if (isLockedColumnId(target.value)) {
           return;
         }
 
@@ -199,7 +199,7 @@ export class ResultsColumnsDropdown {
         }
 
         const item = target.closest(SELECTORS.ITEM) as HTMLElement | null;
-        if (!item || this.isLockedColumn(item.dataset.columnId)) {
+        if (!item || isLockedColumnId(item.dataset.columnId)) {
           return;
         }
 
@@ -263,7 +263,7 @@ export class ResultsColumnsDropdown {
   private render(columns: ColumnConfig[]): void {
     this.list.innerHTML = columns
       .map((column) => {
-        const isLocked = this.isLockedColumn(column.id);
+        const isLocked = isLockedColumnId(column.id);
         return `
           <li class="columns-dropdown-item${isLocked ? ' -locked' : ''}" data-column-id="${column.id}">
             <span class="drag-handle" aria-hidden="true"></span>
@@ -353,7 +353,7 @@ export class ResultsColumnsDropdown {
         return;
       }
 
-      const isTargetLocked = this.isLockedColumn(target.dataset.columnId);
+      const isTargetLocked = isLockedColumnId(target.dataset.columnId);
       const rect = target.getBoundingClientRect();
       const shouldInsertAfter = isTargetLocked
         ? true
@@ -534,12 +534,4 @@ export class ResultsColumnsDropdown {
     }
   }
 
-  /**
-   * 固定列は表示・順序をユーザー操作で崩せないよう、UI操作の各入口で共通判定する。
-   */
-  private isLockedColumn(columnId: string | undefined): boolean {
-    return LOCKED_COLUMN_IDS.includes(
-      columnId as (typeof LOCKED_COLUMN_IDS)[number]
-    );
-  }
 }

--- a/app/frontend/stylesheets/object/project/_results.scss
+++ b/app/frontend/stylesheets/object/project/_results.scss
@@ -581,8 +581,6 @@
           width: 150px;
           min-width: 150px;
           max-width: 150px;
-          overflow: visible;
-          text-overflow: clip;
         }
 
         &.refsnp_id {


### PR DESCRIPTION
styleの修正と、コードのリファクタリングを行いました。

This pull request refactors how locked columns are identified in the `ResultsColumnsDropdown` component and updates some minor UI text and style details. The main change is to centralize the locked column check by reusing a single exported function, which simplifies the code and avoids duplication.

**Refactoring and Code Simplification:**

* Replaced the private `isLockedColumn` method in `ResultsColumnsDropdown` with the exported `isLockedColumnId` function from `columns/index.ts`, ensuring all locked column checks use a single source of truth. [[1]](diffhunk://#diff-54a58395a748b59831d7ba70965b7c4811e7dc905df03697f708964f6e3da053L3-R3) [[2]](diffhunk://#diff-54a58395a748b59831d7ba70965b7c4811e7dc905df03697f708964f6e3da053L165-R165) [[3]](diffhunk://#diff-54a58395a748b59831d7ba70965b7c4811e7dc905df03697f708964f6e3da053L202-R202) [[4]](diffhunk://#diff-54a58395a748b59831d7ba70965b7c4811e7dc905df03697f708964f6e3da053L266-R266) [[5]](diffhunk://#diff-54a58395a748b59831d7ba70965b7c4811e7dc905df03697f708964f6e3da053L356-R356) [[6]](diffhunk://#diff-54a58395a748b59831d7ba70965b7c4811e7dc905df03697f708964f6e3da053L537-L544) [[7]](diffhunk://#diff-894ebddec1eebd63d11b77e960ef33715e03f34bb4a1ad41395b5cab080d1c93L203-R207)

**Minor UI/Text Updates:**

* Removed the period from the "No data." message in `stanza.json` for consistency.
* Removed unnecessary CSS properties (`overflow: visible; text-overflow: clip;`) from the results table column styling for cleaner stylesheets.