### PR TITLE
Refactor/frontend style cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,12 @@ app/frontend/
   - `components/Condition/ConditionItemView.ts`: 1条件行
   - `components/Condition/ConditionValues.ts` と `components/Condition/ConditionValueEditor/*`: 条件入力UI
 - 条件の検索クエリ化は `components/Condition/queryBuilders/` に集約する。
-- Advanced Search のURL共有は `?mode=advanced&q=<Base64 JSON>` を使う。
-- encode/decode処理は `app/frontend/src/store/advancedSearchURL.ts` に集約する。
+- Advanced Search のURL共有は、従来形式 `?mode=advanced&q=<Base64 JSON>` と圧縮形式 `?mode=advanced&qz=<deflate-raw + Base64URL JSON>` を扱う。
+- encode/decode処理は `app/frontend/src/store/advancedSearchURL.ts` に集約する。URL生成時は `encodeConditionForBestURL()` を使い、短い条件では `q`、圧縮した方が短い条件では `qz` を選ぶ。
+- `q` は既存URL互換のため残す。復元時は `qz` を優先し、読めない場合は `q` へフォールバックする。
+- `qz` はブラウザ標準の `CompressionStream` / `DecompressionStream` を使う。追加ライブラリは使わない。非対応環境でURLを生成する場合は従来の `q` 形式へフォールバックする。
+- Advanced Search のURL処理は非同期になっているため、初期復元や `popstate` 復元ではデコード完了後に検索を開始する。
+- `q` / `qz` は共有URL専用の表現であり、Advanced Search のAPIリクエストは引き続きPOST bodyで送る。
 - URLから復元した条件をViewへ戻す処理は `components/AdvancedSearch/AdvancedSearchConditionRestorer.ts` を確認する。
 - Base64はURL中で壊れやすいため、生成時は `encodeURIComponent` を通す。
 - `setAdvancedSearchCondition()` は検索条件をStoreへ保存し、URLへ反映し、検索を実行する。呼び出しタイミングを増やす場合は二重検索に注意する。

--- a/app/frontend/assets/stanza.json
+++ b/app/frontend/assets/stanza.json
@@ -525,6 +525,11 @@
           "page-size": 100,
           "columns": [
             {
+              "id": "report",
+              "label": "Report",
+              "escape": false
+            },
+            {
               "id": "id",
               "label": "TogoVar ID",
               "escape": false
@@ -546,12 +551,7 @@
             },
             {
               "id": "type",
-              "label": "Type",
-              "escape": false
-            },
-            {
-              "id": "symbols",
-              "label": "Gene",
+              "label": "Variant type",
               "escape": false
             },
             {

--- a/app/frontend/src/api/searchMessages.ts
+++ b/app/frontend/src/api/searchMessages.ts
@@ -11,7 +11,10 @@ type SearchMessageResponse = {
  * APIレスポンス内のnotice/warning/errorだけをStoreへ反映し、検索結果処理と分離する。
  */
 export function applySearchMessages(jsonResponse: unknown): void {
-  storeManager.setData('searchMessages', normalizeSearchMessages(jsonResponse));
+  storeManager.setData(
+    'searchMessages',
+    mergeURLRestoreWarning(normalizeSearchMessages(jsonResponse))
+  );
 }
 
 /**
@@ -27,6 +30,19 @@ function normalizeSearchMessages(jsonResponse: unknown): SearchMessages {
   };
 
   return messages.notice || messages.warning || messages.error ? messages : {};
+}
+
+/**
+ * qz共有URLの復元失敗はAPIレスポンス由来ではないため、APIメッセージへ合成して表示を維持する。
+ */
+function mergeURLRestoreWarning(messages: SearchMessages): SearchMessages {
+  const warning = storeManager.getData('advancedSearchURLRestoreWarning');
+  if (!warning) return messages;
+
+  return {
+    ...messages,
+    warning: messages.warning ? `${warning}<br>${messages.warning}` : warning,
+  };
 }
 
 /**

--- a/app/frontend/src/api/searchRequest.ts
+++ b/app/frontend/src/api/searchRequest.ts
@@ -11,6 +11,15 @@ import type { ConditionQuery } from '../types/query';
 
 export const SEARCH_RESULT_LIMIT = 100;
 
+const VARIANT_TYPE_API_TERM_BY_UI_TERM: Readonly<Record<string, string>> = {
+  snv: 'SNV',
+  ins: 'INS',
+  del: 'DEL',
+  indel: 'INDEL',
+  mnv: 'MNV',
+  sub: 'SUB',
+};
+
 /**
  * 検索モードごとのAPI仕様差をここへ閉じ込め、searchExecutor.tsを実行管理に集中させる。
  */
@@ -150,10 +159,61 @@ function buildAdvancedSearchRequestBody(
   };
 
   if (advancedSearchConditions) {
-    body.query = stripAdvancedSearchMetadata(
-      advancedSearchConditions
+    body.query = normalizeAdvancedSearchQueryForAPI(
+      stripAdvancedSearchMetadata(advancedSearchConditions)
     ) as Record<string, unknown>;
   }
 
   return body;
+}
+
+/**
+ * UIとURLでは小文字のtype値を維持し、API送信時だけOpenAPIのenumに合わせる。
+ */
+function normalizeAdvancedSearchQueryForAPI(query: unknown): unknown {
+  if (Array.isArray(query)) {
+    return query.map((item) => normalizeAdvancedSearchQueryForAPI(item));
+  }
+
+  if (!isPlainObject(query)) return query;
+
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(query)) {
+    next[key] =
+      key === 'type'
+        ? normalizeVariantTypeQuery(value)
+        : normalizeAdvancedSearchQueryForAPI(value);
+  }
+
+  return next;
+}
+
+/**
+ * Variant typeだけはUI定義値とAPI enumの表記が異なるため、termsを送信形式へ寄せる。
+ */
+function normalizeVariantTypeQuery(value: unknown): unknown {
+  if (!isPlainObject(value)) return value;
+
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'terms' && Array.isArray(child)) {
+      next[key] = child.map((term) => normalizeVariantTypeTerm(term));
+    } else {
+      next[key] = normalizeAdvancedSearchQueryForAPI(child);
+    }
+  }
+
+  return next;
+}
+
+/**
+ * 既存URLに含まれる小文字type値も検索APIで受け付けられるように変換する。
+ */
+function normalizeVariantTypeTerm(term: unknown): unknown {
+  if (typeof term !== 'string') return term;
+  return VARIANT_TYPE_API_TERM_BY_UI_TERM[term] ?? term;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/app/frontend/src/home.ts
+++ b/app/frontend/src/home.ts
@@ -98,7 +98,7 @@ function setUserAgent(): void {
  * サブスクライバが正しい条件で初回検索を発火できる順序を保証する。
  * StoreManagerの依存順（master → condition → mode）を一箇所で管理するため。
  */
-function readyInitialSearch(callback: () => void): void {
+async function readyInitialSearch(callback: () => void): Promise<void> {
   const simpleSearchConditionsMaster = loadSearchConditionsMaster();
   Object.freeze(simpleSearchConditionsMaster);
   storeManager.setData(
@@ -107,7 +107,7 @@ function readyInitialSearch(callback: () => void): void {
   );
 
   // URLパラメータからAdvanced条件をStoreへ反映し、searchModeを取得する。
-  const searchMode = initializeApp();
+  const searchMode = await initializeApp();
 
   // Simple Searchの初期条件のみURLから復元する。Advanced側はinitializeApp内で処理済み。
   const simpleSearchConditions =

--- a/app/frontend/src/store/advancedSearchURL.ts
+++ b/app/frontend/src/store/advancedSearchURL.ts
@@ -5,6 +5,8 @@ export const ADVANCED_SEARCH_URL_MAX_JSON_LENGTH = 2000;
 export const ADVANCED_SEARCH_URL_RESTORE_WARNING =
   'Could not restore the shared Advanced Search URL. Your browser may not support compressed URL parameters.';
 const ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH = 20000;
+const ADVANCED_SEARCH_DECOMPRESSED_BYTE_MAX_LENGTH =
+  ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH * 4;
 const ADVANCED_SEARCH_COMPRESSED_PARAM_MAX_LENGTH = 20000;
 const ADVANCED_SEARCH_COMPRESSION_FORMAT = 'deflate-raw';
 
@@ -179,7 +181,10 @@ async function decodeCompressedConditionFromURL(
       .pipeThrough(
         new DecompressionStream(ADVANCED_SEARCH_COMPRESSION_FORMAT)
       );
-    const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+    const bytes = await readLimitedStream(
+      stream,
+      ADVANCED_SEARCH_DECOMPRESSED_BYTE_MAX_LENGTH
+    );
     const json = new TextDecoder().decode(bytes);
     if (json.length > ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH) {
       return null;
@@ -268,6 +273,54 @@ function base64URLToBytes(value: string): Uint8Array {
   const binary = atob(base64);
 
   return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+/**
+ * 展開後サイズを読み取り中に制限し、巨大な圧縮入力でタブのメモリを使い切らないようにする。
+ */
+async function readLimitedStream(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      totalLength += value.byteLength;
+      if (totalLength > maxBytes) {
+        await reader.cancel('Decompressed Advanced Search URL is too large.');
+        throw new Error('Decompressed Advanced Search URL is too large.');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return concatenateUint8Arrays(chunks, totalLength);
+}
+
+/**
+ * ReadableStreamのchunk配列を一つのUint8Arrayへまとめ、TextDecoderへ渡せる形にする。
+ */
+function concatenateUint8Arrays(
+  chunks: Uint8Array[],
+  totalLength: number
+): Uint8Array {
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return result;
 }
 
 /**

--- a/app/frontend/src/store/advancedSearchURL.ts
+++ b/app/frontend/src/store/advancedSearchURL.ts
@@ -2,6 +2,24 @@ import type { ConditionQuery } from '../types/query';
 
 /** Advanced Search条件のURLエンコード上限（Raw JSON文字数） */
 export const ADVANCED_SEARCH_URL_MAX_JSON_LENGTH = 2000;
+export const ADVANCED_SEARCH_URL_RESTORE_WARNING =
+  'Could not restore the shared Advanced Search URL. Your browser may not support compressed URL parameters.';
+const ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH = 20000;
+const ADVANCED_SEARCH_COMPRESSED_PARAM_MAX_LENGTH = 20000;
+const ADVANCED_SEARCH_COMPRESSION_FORMAT = 'deflate-raw';
+
+type AdvancedSearchURLParam = {
+  name: 'q' | 'qz';
+  value: string;
+};
+
+export type AdvancedSearchURLDecodeResult = {
+  condition: ConditionQuery | null;
+  hasCompressedParam: boolean;
+  hasLegacyParam: boolean;
+  restoredFromCompressed: boolean;
+  restoredFromLegacy: boolean;
+};
 
 /**
  * Advanced Search条件をURLの `q` パラメータ用にエンコードする。
@@ -20,6 +38,53 @@ export function encodeConditionForURL(query: unknown): string | null {
 }
 
 /**
+ * Advanced Search条件を共有URLへ載せるため、短い条件は従来Base64、長い条件は圧縮Base64URLを優先する。
+ */
+export async function encodeConditionForBestURL(
+  query: unknown
+): Promise<AdvancedSearchURLParam | null> {
+  const legacy = encodeConditionForURL(query);
+  const compressed = await encodeConditionForCompressedURL(query);
+
+  if (legacy === null && compressed === null) return null;
+  if (legacy === null) return { name: 'qz', value: compressed! };
+  if (compressed === null || legacy.length <= compressed.length) {
+    return { name: 'q', value: legacy };
+  }
+  return { name: 'qz', value: compressed };
+}
+
+/**
+ * URL長を抑えるため、Compression Streams API対応ブラウザではJSONをdeflate-raw圧縮してBase64URL化する。
+ */
+async function encodeConditionForCompressedURL(
+  query: unknown
+): Promise<string | null> {
+  try {
+    if (!canUseCompressionStreams()) return null;
+
+    const json = JSON.stringify(query);
+    if (typeof json !== 'string') return null;
+    if (json.length > ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH) {
+      return null;
+    }
+
+    const input = new TextEncoder().encode(json);
+    const stream = new Blob([toArrayBuffer(input)])
+      .stream()
+      .pipeThrough(new CompressionStream(ADVANCED_SEARCH_COMPRESSION_FORMAT));
+    const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
+    const encoded = bytesToBase64URL(compressed);
+
+    return encoded.length <= ADVANCED_SEARCH_COMPRESSED_PARAM_MAX_LENGTH
+      ? encoded
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * URLの `q` パラメータをAdvanced Search条件にデコードする。
  * 既存のURL互換のため、`+` が空白に変換されたケースも補正する。
  */
@@ -30,6 +95,82 @@ export function decodeConditionFromURL(
     const parsed = JSON.parse(atob(encoded.replace(/ /g, '+')));
     // 配列・プリミティブはAPIのquery bodyに流れると不正リクエストになるため弾く。
     // 空オブジェクトは「条件なし」センチネル(undefined)と整合させるため null を返す。
+    if (!isPlainObject(parsed) || Object.keys(parsed).length === 0) return null;
+    return parsed as ConditionQuery;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * URLのAdvanced Search条件は圧縮版qzを優先し、既存URL互換のため従来qへフォールバックする。
+ */
+export async function decodeConditionFromURLParams(params: {
+  q?: unknown;
+  qz?: unknown;
+}): Promise<ConditionQuery | null> {
+  return (await decodeConditionFromURLParamsWithStatus(params)).condition;
+}
+
+/**
+ * qz復元失敗時にUI警告を出すため、条件本体だけでなく復元経路も返す。
+ */
+export async function decodeConditionFromURLParamsWithStatus(params: {
+  q?: unknown;
+  qz?: unknown;
+}): Promise<AdvancedSearchURLDecodeResult> {
+  const compressed = getFirstString(params.qz);
+  if (compressed) {
+    const condition = await decodeCompressedConditionFromURL(compressed);
+    if (condition !== null) {
+      return {
+        condition,
+        hasCompressedParam: true,
+        hasLegacyParam: getFirstString(params.q) !== undefined,
+        restoredFromCompressed: true,
+        restoredFromLegacy: false,
+      };
+    }
+  }
+
+  const legacy = getFirstString(params.q);
+  const legacyCondition = legacy ? decodeConditionFromURL(legacy) : null;
+  return {
+    condition: legacyCondition,
+    hasCompressedParam: compressed !== undefined,
+    hasLegacyParam: legacy !== undefined,
+    restoredFromCompressed: false,
+    restoredFromLegacy: legacyCondition !== null,
+  };
+}
+
+/**
+ * qzは圧縮済みバイト列のBase64URL表現なので、Base64URL復元後に展開してJSONとして読む。
+ */
+async function decodeCompressedConditionFromURL(
+  encoded: string
+): Promise<ConditionQuery | null> {
+  try {
+    if (
+      !canUseCompressionStreams() ||
+      encoded.length > ADVANCED_SEARCH_COMPRESSED_PARAM_MAX_LENGTH
+    ) {
+      return null;
+    }
+
+    const compressed = base64URLToBytes(encoded);
+    const stream = new Blob([toArrayBuffer(compressed)])
+      .stream()
+      .pipeThrough(
+        new DecompressionStream(ADVANCED_SEARCH_COMPRESSION_FORMAT)
+      );
+    const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+    const json = new TextDecoder().decode(bytes);
+    if (json.length > ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH) {
+      return null;
+    }
+
+    const parsed = JSON.parse(json);
     if (!isPlainObject(parsed) || Object.keys(parsed).length === 0) return null;
     return parsed as ConditionQuery;
   } catch {
@@ -58,4 +199,68 @@ export function stripAdvancedSearchMetadata(query: unknown): unknown {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Compression Streams API非対応ブラウザでは従来q形式へフォールバックするため、実行前に機能検出する。
+ */
+function canUseCompressionStreams(): boolean {
+  return (
+    typeof CompressionStream !== 'undefined' &&
+    typeof DecompressionStream !== 'undefined'
+  );
+}
+
+/**
+ * URLSearchParamsとqs.parse()の両方から同じように単一文字列を取り出す。
+ */
+function getFirstString(value: unknown): string | undefined {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  return typeof candidate === 'string' ? candidate : undefined;
+}
+
+/**
+ * 圧縮済みバイト列をURLで扱いやすくするため、`+` `/` `=` を含まないBase64URLへ変換する。
+ */
+function bytesToBase64URL(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize)
+    );
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+/**
+ * qzの不正文字を先に弾き、atob()には通常Base64へ戻した値だけを渡す。
+ */
+function base64URLToBytes(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]*$/.test(value)) {
+    throw new Error('Invalid Base64URL value.');
+  }
+
+  const base64 = value
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .padEnd(Math.ceil(value.length / 4) * 4, '=');
+  const binary = atob(base64);
+
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+/**
+ * BlobPartの型をArrayBufferへ揃え、SharedArrayBuffer混在の型エラーを避ける。
+ */
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer;
 }

--- a/app/frontend/src/store/advancedSearchURL.ts
+++ b/app/frontend/src/store/advancedSearchURL.ts
@@ -145,6 +145,21 @@ export async function decodeConditionFromURLParamsWithStatus(params: {
 }
 
 /**
+ * qzを含む共有URLがどの経路でも復元できなかった場合だけ、ユーザーへ警告する。
+ */
+export function shouldWarnAdvancedSearchURLRestoreFailure(
+  result: AdvancedSearchURLDecodeResult,
+  restoredCondition: ConditionQuery | null
+): boolean {
+  return (
+    result.hasCompressedParam &&
+    !result.restoredFromCompressed &&
+    !result.restoredFromLegacy &&
+    restoredCondition === null
+  );
+}
+
+/**
  * qzは圧縮済みバイト列のBase64URL表現なので、Base64URL復元後に展開してJSONとして読む。
  */
 async function decodeCompressedConditionFromURL(

--- a/app/frontend/src/store/initializeApp.ts
+++ b/app/frontend/src/store/initializeApp.ts
@@ -2,6 +2,7 @@ import { storeManager } from './StoreManager';
 import {
   ADVANCED_SEARCH_URL_RESTORE_WARNING,
   decodeConditionFromURLParamsWithStatus,
+  shouldWarnAdvancedSearchURLRestoreFailure,
   type AdvancedSearchURLDecodeResult,
 } from './advancedSearchURL';
 import { initSearchHandlers } from './searchManager';
@@ -41,11 +42,10 @@ export async function initializeApp(): Promise<'simple' | 'advanced'> {
 export function updateAdvancedSearchURLRestoreWarning(
   result: AdvancedSearchURLDecodeResult
 ): void {
-  const shouldWarn =
-    result.hasCompressedParam &&
-    !result.hasLegacyParam &&
-    !result.restoredFromCompressed &&
-    !result.restoredFromLegacy;
+  const shouldWarn = shouldWarnAdvancedSearchURLRestoreFailure(
+    result,
+    result.condition
+  );
   storeManager.setData(
     'advancedSearchURLRestoreWarning',
     shouldWarn ? ADVANCED_SEARCH_URL_RESTORE_WARNING : undefined

--- a/app/frontend/src/store/initializeApp.ts
+++ b/app/frontend/src/store/initializeApp.ts
@@ -1,5 +1,9 @@
 import { storeManager } from './StoreManager';
-import { decodeConditionFromURL } from './advancedSearchURL';
+import {
+  ADVANCED_SEARCH_URL_RESTORE_WARNING,
+  decodeConditionFromURLParamsWithStatus,
+  type AdvancedSearchURLDecodeResult,
+} from './advancedSearchURL';
 import { initSearchHandlers } from './searchManager';
 
 /**
@@ -7,7 +11,7 @@ import { initSearchHandlers } from './searchManager';
  * searchModeはここでセットしない。条件がストアに揃った後で呼び出し元がセットし、
  * Store内部リセット後にsearchManager側の副作用ハンドラが検索を開始する。
  */
-export function initializeApp(): 'simple' | 'advanced' {
+export async function initializeApp(): Promise<'simple' | 'advanced'> {
   // searchMode subscriber と popstate リスナーを登録する。
   // storeManager.setSearchModeFromHistory() が呼ばれる前に必ず実行する必要がある。
   initSearchHandlers();
@@ -15,16 +19,35 @@ export function initializeApp(): 'simple' | 'advanced' {
   const urlMode = searchParams.get('mode');
 
   if (urlMode === 'advanced') {
-    const encodedCondition = searchParams.get('q');
-    if (encodedCondition) {
-      const condition = decodeConditionFromURL(encodedCondition);
-      if (condition !== null) {
-        storeManager.setData('advancedSearchConditions', condition);
-        storeManager.setData('advancedSearchRestoredFromURL', true);
-      }
+    const result = await decodeConditionFromURLParamsWithStatus({
+      q: searchParams.get('q'),
+      qz: searchParams.get('qz'),
+    });
+    updateAdvancedSearchURLRestoreWarning(result);
+    const condition = result.condition;
+    if (condition !== null) {
+      storeManager.setData('advancedSearchConditions', condition);
+      storeManager.setData('advancedSearchRestoredFromURL', true);
     }
     return 'advanced';
   } else {
     return 'simple';
   }
+}
+
+/**
+ * qzだけの共有URLが復元できなかった場合、空条件で黙って検索されないよう警告を残す。
+ */
+export function updateAdvancedSearchURLRestoreWarning(
+  result: AdvancedSearchURLDecodeResult
+): void {
+  const shouldWarn =
+    result.hasCompressedParam &&
+    !result.hasLegacyParam &&
+    !result.restoredFromCompressed &&
+    !result.restoredFromLegacy;
+  storeManager.setData(
+    'advancedSearchURLRestoreWarning',
+    shouldWarn ? ADVANCED_SEARCH_URL_RESTORE_WARNING : undefined
+  );
 }

--- a/app/frontend/src/store/searchHistory.ts
+++ b/app/frontend/src/store/searchHistory.ts
@@ -4,11 +4,15 @@ import type {
   SimpleSearchCurrentConditions,
 } from '../types';
 import type { ConditionQuery } from '../types/query';
-import { storeManager } from './StoreManager';
 import {
-  ADVANCED_SEARCH_URL_RESTORE_WARNING,
   decodeConditionFromURLParamsWithStatus,
+  shouldWarnAdvancedSearchURLRestoreFailure,
 } from './advancedSearchURL';
+
+export type AdvancedSearchHistoryRestoreResult = {
+  condition: ConditionQuery | null;
+  shouldWarn: boolean;
+};
 
 /**
  * popstate時のURL/state解釈をここへ閉じ込め、searchManager.tsを検索開始判断に集中させる。
@@ -16,19 +20,14 @@ import {
 export function getAdvancedConditionFromHistory(
   urlParams: Record<string, unknown>,
   state: unknown
-): Promise<ConditionQuery | null> {
+): Promise<AdvancedSearchHistoryRestoreResult> {
   return decodeConditionFromURLParamsWithStatus(urlParams).then((result) => {
     const condition = result.condition ?? getConditionFromHistoryState(state);
-    const shouldWarn =
-      result.hasCompressedParam &&
-      !result.hasLegacyParam &&
-      result.condition === null &&
-      condition === null;
-    storeManager.setData(
-      'advancedSearchURLRestoreWarning',
-      shouldWarn ? ADVANCED_SEARCH_URL_RESTORE_WARNING : undefined
+    const shouldWarn = shouldWarnAdvancedSearchURLRestoreFailure(
+      result,
+      condition
     );
-    return condition;
+    return { condition, shouldWarn };
   });
 }
 

--- a/app/frontend/src/store/searchHistory.ts
+++ b/app/frontend/src/store/searchHistory.ts
@@ -4,7 +4,11 @@ import type {
   SimpleSearchCurrentConditions,
 } from '../types';
 import type { ConditionQuery } from '../types/query';
-import { decodeConditionFromURL } from './advancedSearchURL';
+import { storeManager } from './StoreManager';
+import {
+  ADVANCED_SEARCH_URL_RESTORE_WARNING,
+  decodeConditionFromURLParamsWithStatus,
+} from './advancedSearchURL';
 
 /**
  * popstate時のURL/state解釈をここへ閉じ込め、searchManager.tsを検索開始判断に集中させる。
@@ -12,14 +16,20 @@ import { decodeConditionFromURL } from './advancedSearchURL';
 export function getAdvancedConditionFromHistory(
   urlParams: Record<string, unknown>,
   state: unknown
-): ConditionQuery | null {
-  const qParam = urlParams.q;
-  const first = Array.isArray(qParam) ? qParam[0] : qParam;
-  const encoded = typeof first === 'string' ? first : undefined;
-
-  return encoded
-    ? decodeConditionFromURL(encoded)
-    : getConditionFromHistoryState(state);
+): Promise<ConditionQuery | null> {
+  return decodeConditionFromURLParamsWithStatus(urlParams).then((result) => {
+    const condition = result.condition ?? getConditionFromHistoryState(state);
+    const shouldWarn =
+      result.hasCompressedParam &&
+      !result.hasLegacyParam &&
+      result.condition === null &&
+      condition === null;
+    storeManager.setData(
+      'advancedSearchURLRestoreWarning',
+      shouldWarn ? ADVANCED_SEARCH_URL_RESTORE_WARNING : undefined
+    );
+    return condition;
+  });
 }
 
 /**

--- a/app/frontend/src/store/searchManager.ts
+++ b/app/frontend/src/store/searchManager.ts
@@ -119,7 +119,7 @@ function createSimpleSearchResetConditions(): Partial<SimpleSearchCurrentConditi
 /**
  * ブラウザの戻る/進むではURLを正本として復元し、自動遷移は必ず無効化する。
  */
-export function handleHistoryChange(e: PopStateEvent): void {
+export async function handleHistoryChange(e: PopStateEvent): Promise<void> {
   prepareHistoryNavigationSearch();
 
   const urlParams = parseSearchURLParams();
@@ -127,7 +127,7 @@ export function handleHistoryChange(e: PopStateEvent): void {
   const currentMode = storeManager.getData('searchMode');
 
   if (mode === 'advanced') {
-    restoreAdvancedSearchFromHistory(urlParams, e.state, currentMode);
+    await restoreAdvancedSearchFromHistory(urlParams, e.state, currentMode);
     return;
   }
 
@@ -149,17 +149,18 @@ function restoreAdvancedSearchFromHistory(
   urlParams: Record<string, unknown>,
   historyState: unknown,
   currentMode: SearchMode | ''
-): void {
-  const restoredCondition = getAdvancedConditionFromHistory(
+): Promise<void> {
+  return getAdvancedConditionFromHistory(
     urlParams,
     historyState
-  );
-  storeManager.setData(
-    'advancedSearchConditions',
-    restoredCondition ?? undefined
-  );
-  notifyAdvancedSearchBuilderRestored();
-  continueHistorySearchInMode('advanced', currentMode);
+  ).then((restoredCondition) => {
+    storeManager.setData(
+      'advancedSearchConditions',
+      restoredCondition ?? undefined
+    );
+    notifyAdvancedSearchBuilderRestored();
+    continueHistorySearchInMode('advanced', currentMode);
+  });
 }
 
 /**
@@ -218,8 +219,12 @@ export function setAdvancedSearchCondition(
  */
 function reflectCurrentAdvancedConditionToUrl(): void {
   const conditions = storeManager.getData('advancedSearchConditions');
-  const { isURLTooLong } = reflectAdvancedSearchConditionToURI(conditions);
-  storeManager.setData('advancedSearchURLTooLong', isURLTooLong);
+  void reflectAdvancedSearchConditionToURI(conditions).then(
+    ({ isURLTooLong, isStale }) => {
+      if (isStale) return;
+      storeManager.setData('advancedSearchURLTooLong', isURLTooLong);
+    }
+  );
 }
 
 /**

--- a/app/frontend/src/store/searchManager.ts
+++ b/app/frontend/src/store/searchManager.ts
@@ -12,6 +12,7 @@ import type {
   SearchMode,
 } from '../types';
 import type { ConditionQuery } from '../types/query';
+import { ADVANCED_SEARCH_URL_RESTORE_WARNING } from './advancedSearchURL';
 import {
   buildSimpleConditionsFromURL,
   getAdvancedConditionFromHistory,
@@ -21,6 +22,8 @@ import {
   reflectAdvancedSearchConditionToURI,
   reflectSimpleSearchConditionToURI,
 } from './searchURL';
+
+let historyRestoreId = 0;
 
 // ================================================================
 // Simple Search 条件更新
@@ -42,6 +45,8 @@ function applySimpleSearchConditionPatch(
   newSearchConditions: Partial<SimpleSearchCurrentConditions>
 ): void {
   if (storeManager.getData('searchMode') !== 'simple') return;
+  invalidatePendingHistoryRestore();
+  clearAdvancedSearchURLRestoreWarning();
 
   const updatedConditions = {
     ...storeManager.getData('simpleSearchConditions'),
@@ -121,16 +126,23 @@ function createSimpleSearchResetConditions(): Partial<SimpleSearchCurrentConditi
  */
 export async function handleHistoryChange(e: PopStateEvent): Promise<void> {
   prepareHistoryNavigationSearch();
+  const restoreId = invalidatePendingHistoryRestore();
 
   const urlParams = parseSearchURLParams();
   const mode = normalizeModeParam(urlParams.mode);
   const currentMode = storeManager.getData('searchMode');
 
   if (mode === 'advanced') {
-    await restoreAdvancedSearchFromHistory(urlParams, e.state, currentMode);
+    await restoreAdvancedSearchFromHistory(
+      urlParams,
+      e.state,
+      currentMode,
+      restoreId
+    );
     return;
   }
 
+  if (!isCurrentHistoryRestore(restoreId)) return;
   restoreSimpleSearchFromHistory(urlParams, currentMode);
 }
 
@@ -148,15 +160,18 @@ function normalizeModeParam(rawMode: unknown): string | undefined {
 function restoreAdvancedSearchFromHistory(
   urlParams: Record<string, unknown>,
   historyState: unknown,
-  currentMode: SearchMode | ''
+  currentMode: SearchMode | '',
+  restoreId: number
 ): Promise<void> {
   return getAdvancedConditionFromHistory(
     urlParams,
     historyState
-  ).then((restoredCondition) => {
+  ).then((restoreResult) => {
+    if (!isCurrentHistoryRestore(restoreId)) return;
+    setAdvancedSearchURLRestoreWarning(restoreResult.shouldWarn);
     storeManager.setData(
       'advancedSearchConditions',
-      restoredCondition ?? undefined
+      restoreResult.condition ?? undefined
     );
     notifyAdvancedSearchBuilderRestored();
     continueHistorySearchInMode('advanced', currentMode);
@@ -170,6 +185,7 @@ function restoreSimpleSearchFromHistory(
   urlParams: Record<string, unknown>,
   currentMode: SearchMode | ''
 ): void {
+  clearAdvancedSearchURLRestoreWarning();
   const restoredConditions = buildSimpleConditionsFromURL(
     urlParams,
     storeManager.getData('simpleSearchConditionsMaster') ?? []
@@ -203,6 +219,8 @@ function continueHistorySearchInMode(
 export function setAdvancedSearchCondition(
   newSearchConditions: ConditionQuery
 ): void {
+  invalidatePendingHistoryRestore();
+  clearAdvancedSearchURLRestoreWarning();
   const normalizedConditions =
     Object.keys(newSearchConditions).length === 0
       ? undefined
@@ -212,6 +230,38 @@ export function setAdvancedSearchCondition(
   reflectCurrentAdvancedConditionToUrl();
 
   requestInitialSearch('user');
+}
+
+/**
+ * qz復元失敗の警告は、その後の通常操作や別履歴復元へ持ち越さない。
+ */
+function clearAdvancedSearchURLRestoreWarning(): void {
+  setAdvancedSearchURLRestoreWarning(false);
+}
+
+/**
+ * 復元警告の文言を一箇所で扱い、boolean判定と表示文言の散在を避ける。
+ */
+function setAdvancedSearchURLRestoreWarning(shouldWarn: boolean): void {
+  storeManager.setData(
+    'advancedSearchURLRestoreWarning',
+    shouldWarn ? ADVANCED_SEARCH_URL_RESTORE_WARNING : undefined
+  );
+}
+
+/**
+ * popstate復元は非同期なので、古い戻る/進むの復元結果が最新URLの状態を上書きしないようにする。
+ */
+function isCurrentHistoryRestore(restoreId: number): boolean {
+  return restoreId === historyRestoreId;
+}
+
+/**
+ * 新しい履歴復元やユーザー操作が始まった時点で、未完了の古い履歴復元を無効化する。
+ */
+function invalidatePendingHistoryRestore(): number {
+  historyRestoreId += 1;
+  return historyRestoreId;
 }
 
 /**
@@ -246,6 +296,9 @@ function handleSearchModeChange(mode: SearchMode | ''): void {
   if (!mode) return;
 
   reflectSearchModeToBodyDataset(mode);
+  if (!storeManager.fromHistory) {
+    clearAdvancedSearchURLRestoreWarning();
+  }
 
   switch (mode) {
     case 'simple':

--- a/app/frontend/src/store/searchManager.ts
+++ b/app/frontend/src/store/searchManager.ts
@@ -142,7 +142,6 @@ export async function handleHistoryChange(e: PopStateEvent): Promise<void> {
     return;
   }
 
-  if (!isCurrentHistoryRestore(restoreId)) return;
   restoreSimpleSearchFromHistory(urlParams, currentMode);
 }
 

--- a/app/frontend/src/store/searchURL.ts
+++ b/app/frontend/src/store/searchURL.ts
@@ -1,30 +1,38 @@
 import * as qs from 'qs';
 import type { ConditionQuery, MasterConditions, SimpleSearchCurrentConditions } from '../types';
-import { encodeConditionForURL } from './advancedSearchURL';
+import { encodeConditionForBestURL } from './advancedSearchURL';
 import { extractSearchCondition } from './simpleSearchConditions';
 
 type SearchUrlParams = Record<string, unknown>;
+type AdvancedSearchURLReflectionResult = {
+  isURLTooLong: boolean;
+  isStale: boolean;
+};
 
 let currentUrlParams: SearchUrlParams = qs.parse(
   window.location.search.substring(1)
 );
+let advancedUrlReflectionId = 0;
 
 // ## Advanced Search URL仕様
 //
 // ### URLフォーマット
 //   条件あり: ?mode=advanced&q=<Base64エンコードされたJSON>
+//   圧縮版: ?mode=advanced&qz=<deflate-raw圧縮後にBase64URLエンコードされたJSON>
 //   条件なし: ?mode=advanced
 //
 // ### エンコード方式
 //   条件オブジェクト → JSON.stringify() → btoa() (Base64) → encodeURIComponent() → `q` パラメータ
+//   長い条件では CompressionStream(deflate-raw) → Base64URL → `qz` パラメータ
 //
 // ### 文字数制限
-//   - Raw JSON (btoa前) が2000文字以内の場合のみ `q` パラメータをURLに付与する
-//   - 2000文字を超える場合はURLを `?mode=advanced` のみにし、条件はhistory.stateへ退避する
+//   - Raw JSON が2000文字以内の場合は従来の `q` を候補にする
+//   - CompressionStream対応環境ではRaw JSON 20000文字以内を `qz` の候補にする
+//   - どちらも使えない場合はURLを `?mode=advanced` のみにし、条件はhistory.stateへ退避する
 //
 // ### Simple Searchとの比較
 //   Simple Search: qs.stringify() でフラットなkey=valueをURLに展開
-//   Advanced Search: ネスト構造のためJSON+Base64を使用（URI encodeより~33%コンパクト）
+//   Advanced Search: ネスト構造のためJSON+Base64または圧縮JSON+Base64URLを使用
 
 /**
  * Simple Search条件のURL表現をここに閉じ込め、検索開始ロジックからpushStateを分離する。
@@ -59,19 +67,25 @@ export function reflectSimpleSearchConditionToURI(
 /**
  * Advanced Search条件のURL表現と履歴state退避をここに集約し、長すぎる条件だけ呼び出し元へ返す。
  */
-export function reflectAdvancedSearchConditionToURI(
+export async function reflectAdvancedSearchConditionToURI(
   conditions: ConditionQuery | undefined
-): { isURLTooLong: boolean } {
+): Promise<AdvancedSearchURLReflectionResult> {
+  const reflectionId = ++advancedUrlReflectionId;
   // conditions は setAdvancedSearchCondition で {} → undefined に正規化されるため、存在確認だけで十分。
   const hasConditions = conditions !== undefined;
-  const encoded = hasConditions ? encodeConditionForURL(conditions) : null;
+  const encoded = hasConditions
+    ? await encodeConditionForBestURL(conditions)
+    : null;
+  if (reflectionId !== advancedUrlReflectionId) {
+    return { isURLTooLong: false, isStale: true };
+  }
 
   let url: string;
   if (encoded !== null) {
-    url = `${window.location.origin}${
-      window.location.pathname
-    }?mode=advanced&q=${encodeURIComponent(encoded)}`;
-    currentUrlParams = { mode: 'advanced', q: encoded };
+    const params = new URLSearchParams({ mode: 'advanced' });
+    params.set(encoded.name, encoded.value);
+    url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+    currentUrlParams = { mode: 'advanced', [encoded.name]: encoded.value };
   } else {
     url = `${window.location.origin}${window.location.pathname}?mode=advanced`;
     currentUrlParams = { mode: 'advanced' };
@@ -85,7 +99,7 @@ export function reflectAdvancedSearchConditionToURI(
 
   pushAdvancedSearchUrl(state, url);
 
-  return { isURLTooLong };
+  return { isURLTooLong, isStale: false };
 }
 
 /**

--- a/app/frontend/src/types/storeState.ts
+++ b/app/frontend/src/types/storeState.ts
@@ -77,6 +77,7 @@ export type StoreState = {
   selectedRow?: number;
   advancedSearchConditions?: ConditionQuery;
   advancedSearchURLTooLong?: boolean;
+  advancedSearchURLRestoreWarning?: string;
   advancedSearchRestoredFromURL?: boolean;
   searchMessages?: SearchMessages;
   searchStatus?: SearchStatus;

--- a/app/frontend/stylesheets/object/project/_detail.scss
+++ b/app/frontend/stylesheets/object/project/_detail.scss
@@ -164,7 +164,7 @@
       min-height: 679px;
     }
     &#gene-variant {
-      min-height: 515px;
+      min-height: 400px;
     }
 
     togostanza-gene-protein-structure {

--- a/app/frontend/stylesheets/object/project/_detail.scss
+++ b/app/frontend/stylesheets/object/project/_detail.scss
@@ -17,10 +17,10 @@
   background: var(--gradient-heading-semitransparent);
 
   .title-wrapper {
-    flex: 0 0 auto;
     display: inline-block;
-    padding-right: 20px;
+    flex: 0 0 auto;
     min-width: 0;
+    padding-right: 20px;
     vertical-align: bottom;
 
     &:first-child {


### PR DESCRIPTION
## 概要

このPRでは、Advanced Search の検索条件URL共有・復元処理を改善しました。

長い検索条件でも共有しやすくするため、従来の `q` パラメータに加えて、圧縮済みの `qz` パラメータをサポートしています。あわせて、URL復元時のエラーハンドリング、非同期復元時の競合対策、APIリクエスト用の検索条件正規化、検索結果テーブル設定の更新を行いました。

## 主な変更内容

### Advanced Search URL共有・復元の改善

- Advanced Search の検索条件URLに、圧縮形式の `qz` パラメータを追加しました。
- `qz` は `deflate-raw` で圧縮したJSONを Base64URL 形式に変換して保持します。
- 既存の `q` パラメータも引き続きサポートし、URL生成時は `q` と `qz` のうち短い形式を使用します。
- URL復元時は `qz` を優先し、復元できない場合は従来の `q` にフォールバックします。
- 圧縮・解凍にはブラウザ標準の `CompressionStream` / `DecompressionStream` を使用します。
- 圧縮URLに対応していないブラウザでも、従来の `q` パラメータはそのまま利用できます。

### 非同期復元処理の安全性向上

- `qz` の解凍処理が非同期になるため、URL復元が完了してから検索を実行するように変更しました。
- ブラウザの戻る・進む操作を連続で行った場合でも、古い復元結果が最新の検索条件を上書きしないようにしました。
- URL反映処理でも、古い非同期処理が後から完了して現在のURLを上書きしないようにしています。
- 解凍後のデータサイズに上限を設け、過大な圧縮データを読み込み続けないようにしました。

### 復元失敗時の警告表示

- `qz` 付きURLの復元に失敗し、従来の `q` でも復元できない場合は、ユーザーに警告を表示するようにしました。
- 警告は検索APIから返るメッセージと統合して表示されます。
- ユーザーが条件を変更した場合や検索モードを切り替えた場合は、古い警告が残らないようにしています。

### APIリクエスト用の検索条件正規化

- Advanced Search の `type` 条件を、APIが期待する OpenAPI enum 形式に正規化するようにしました。
- 例: `snv` → `SNV`
- UIやURL上の表現に関わらず、APIへ送信する値が仕様に合うようにしています。

### 検索結果テーブル設定の更新

- `stanza.json` の検索結果テーブル設定に、Variant report へ遷移するための `Report` 列を追加しました。
- `Type` 列のラベルを `Variant type` に変更しました。