### PR TITLE
Advanced Search URL圧縮の調整とHistoryページの表示整理

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ app/frontend/
   - `components/Condition/ConditionValues.ts` と `components/Condition/ConditionValueEditor/*`: 条件入力UI
 - 条件の検索クエリ化は `components/Condition/queryBuilders/` に集約する。
 - Advanced Search のURL共有は、従来形式 `?mode=advanced&q=<Base64 JSON>` と圧縮形式 `?mode=advanced&qz=<deflate-raw + Base64URL JSON>` を扱う。
-- encode/decode処理は `app/frontend/src/store/advancedSearchURL.ts` に集約する。URL生成時は `encodeConditionForBestURL()` を使い、短い条件では `q`、圧縮した方が短い条件では `qz` を選ぶ。
+- encode/decode処理は `app/frontend/src/store/advancedSearchURL.ts` に集約する。URL生成時は `encodeConditionForBestURL()` を使い、短い条件では圧縮を試さず `q`、長い条件では圧縮結果を比較して短い方を選ぶ。
 - `q` は既存URL互換のため残す。復元時は `qz` を優先し、読めない場合は `q` へフォールバックする。
 - `qz` はブラウザ標準の `CompressionStream` / `DecompressionStream` を使う。追加ライブラリは使わない。非対応環境でURLを生成する場合は従来の `q` 形式へフォールバックする。
 - Advanced Search のURL処理は非同期になっているため、初期復元や `popstate` 復元ではデコード完了後に検索を開始する。

--- a/app/frontend/assets/stanza.json
+++ b/app/frontend/assets/stanza.json
@@ -197,7 +197,10 @@
       {
         "id": "variant-transcript",
         "targetSelector": "#variant-transcript",
-        "references": ["GRCh37", "GRCh38"]
+        "references": ["GRCh37", "GRCh38"],
+        "options": {
+          "assembly": "$TOGOVAR_FRONTEND_REFERENCE"
+        }
       },
       {
         "id": "variant-publication",

--- a/app/frontend/src/store/advancedSearchURL.ts
+++ b/app/frontend/src/store/advancedSearchURL.ts
@@ -8,6 +8,7 @@ const ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH = 20000;
 const ADVANCED_SEARCH_DECOMPRESSED_BYTE_MAX_LENGTH =
   ADVANCED_SEARCH_COMPRESSED_URL_MAX_JSON_LENGTH * 4;
 const ADVANCED_SEARCH_COMPRESSED_PARAM_MAX_LENGTH = 20000;
+const ADVANCED_SEARCH_COMPRESSION_MIN_LEGACY_LENGTH = 600;
 const ADVANCED_SEARCH_COMPRESSION_FORMAT = 'deflate-raw';
 
 type AdvancedSearchURLParam = {
@@ -46,6 +47,13 @@ export async function encodeConditionForBestURL(
   query: unknown
 ): Promise<AdvancedSearchURLParam | null> {
   const legacy = encodeConditionForURL(query);
+  if (
+    legacy !== null &&
+    legacy.length <= ADVANCED_SEARCH_COMPRESSION_MIN_LEGACY_LENGTH
+  ) {
+    return { name: 'q', value: legacy };
+  }
+
   const compressed = await encodeConditionForCompressedURL(query);
 
   if (legacy === null && compressed === null) return null;

--- a/app/frontend/stylesheets/object/project/_history.scss
+++ b/app/frontend/stylesheets/object/project/_history.scss
@@ -5,79 +5,95 @@
 .history-document {
   > .contents {
     > .timeline {
-      display: grid;
-      grid-template-columns: 140px minmax(0, 1fr);
-      column-gap: 12px;
-      align-items: start;
       padding-top: 16px;
 
-      // 日付と変更内容を横にそろえ、長い履歴から目的のリリースを探しやすくする
-      > .heading {
-        padding: 12px 0;
-        font-size: 15px;
-        line-height: 1.4;
-        border-top: solid 2px color-mix(in srgb, var(--color-key) 45%, transparent);
+      // 1リリースを1行のグリッドにし、日付と変更内容の関係をHTML構造でも明確にする
+      > .release {
+        position: relative;
+        display: grid;
+        grid-template-columns: 120px minmax(0, 1fr);
+        column-gap: 12px;
+        align-items: start;
+        padding: 30px 0;
 
-        > .date,
-        > .number {
+        &::before {
+          position: absolute;
+          top: 0;
+          left: 0;
           display: block;
+          width: 100%;
+          height: 1px;
+          content: '';
+          background-color: var(--color-key-dark1);
         }
 
-        > .number {
-          margin-top: 2px;
-          font-size: 12px;
-          font-weight: normal;
-          color: var(--color-gray);
-        }
-      }
-
-      // リリースごとの内容をひとまとまりにしつつ、縦方向の一覧性を保つ
-      > .items {
-        padding: 8px 16px;
-        margin-bottom: 20px;
-        background-color: color-mix(in srgb, var(--color-key) 4%, transparent);
-        border-top: solid 2px color-mix(in srgb, var(--color-key) 45%, transparent);
-
-        > li {
-          padding: 7px 0 7px 16px;
-          line-height: 1.65;
+        &:first-of-type {
+          padding-top: 0;
 
           &::before {
-            position: absolute;
-            top: 15px;
-            left: 2px;
+            display: none;
+          }
+        }
+
+        &:last-of-type {
+          padding-bottom: 0;
+        }
+
+        // 日付と変更内容を横にそろえ、長い履歴から目的のリリースを探しやすくする
+        > .heading {
+          position: relative;
+          top: 2px;
+          font-size: 18px;
+          color: var(--color-key-dark3);
+
+          > .date,
+          > .number {
+            display: block;
           }
 
-          + li {
-            border-top: solid 1px color-mix(in srgb, var(--color-black) 12%, transparent);
-          }
-
-          // 項目種別を短い見出しとして認識しやすくする
-          > strong:first-child {
-            display: inline-block;
-            padding: 0 6px;
+          > .number {
+            margin-top: 2px;
             font-size: 12px;
-            line-height: 1.7;
-            color: var(--color-key-dark1);
-            background-color: color-mix(in srgb, var(--color-key) 12%, transparent);
-            border-radius: 3px;
+            font-weight: normal;
+            color: var(--color-gray);
           }
+        }
 
-          // 詳細項目は左罫線でまとめ、上位項目との階層を明確にする
-          > .unordered-list {
-            padding: 4px 0 2px 14px;
-            margin: 5px 0 0 2px;
-            border-left: solid 2px color-mix(in srgb, var(--color-key) 24%, transparent);
+        // リリースごとの内容をひとまとまりにしつつ、縦方向の一覧性を保つ
+        > .items {
+          > li {
+            padding: 7px 0 7px 16px;
+            line-height: 1.65;
 
-            > li {
-              padding: 3px 0 3px 14px;
+            &::before {
+              position: absolute;
+              top: 15px;
+              left: 2px;
+            }
 
-              &::before {
-                position: absolute;
-                top: 11px;
-                left: 1px;
-                width: 4px;
-                height: 4px;
+            + li {
+              border-top: solid 1px color-mix(in srgb, var(--color-black) 12%, transparent);
+            }
+
+            // 項目種別を短い見出しとして認識しやすくする
+            > strong:first-child {
+              color: var(--color-key-dark1);
+            }
+
+            // 詳細項目は左罫線でまとめ、上位項目との階層を明確にする
+            > .unordered-list {
+              padding-left: 18px;
+
+              > li {
+                padding: 3px 0 3px 14px;
+
+                &::before {
+                  position: absolute;
+                  top: 11px;
+                  left: 1px;
+                  width: 4px;
+                  height: 4px;
+                }
               }
             }
           }

--- a/app/frontend/views/doc/en/history.pug
+++ b/app/frontend/views/doc/en/history.pug
@@ -17,449 +17,463 @@ block content
       .contents
         section.section.timeline
           //- Replace “X” when the release date is confirmed.
-          h3.sectiontitle.heading
-            span.date 2026/8/X
-            span.number Release: 2026.1
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  New frequency datasets were added to GRCh38, and existing datasets were updated.
-              ul.unordered-list
-                li
-                  | Allele frequencies and genotype counts for
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/bbj1k') BBJ1K
-                  |  (WGS of 1,026 BioBank Japan participants) and
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/bbj2k') BBJ2K
-                  |  (WGS of 1,964 BioBank Japan participants) were added to
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/jga_wgs') JGA-WGS
-                  |  as two datasets, bringing it to a total of six datasets and 3,068 individuals.
-                li
-                  a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-jsv1-20211208-af') ToMMo JSV1
-                  | , a structural-variant frequency dataset based on long-read WGS of 222 Japanese individuals, was added.
-                li
-                  | Alternate allele frequencies including structural variants derived from
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://jogo.csml.org/') JoGo 1.0
-                  | , a human gene haplotype database based on long-read WGS, were added.
-                li
-                  | ToMMo 54KJPN was updated to
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-61kjpn-20250616-af_snvindelall') 61KJPN
-                  |  (61,424 individuals).
-            li
-              strong Simple/Advanced Search:
-              |  #[a.hyper-text.-external(target='_blank', href='https://cadd.bihealth.org/') CADD] (PHRED score) and predicted splicing types from #[a.hyper-text.-external(target='_blank', href='https://sscvdb.io/') SSCV DB] were added as search filters and result fields.
-            li
-              strong Advanced Search:
-              |  Genotype-count searches for Alt/Alt, Alt/Ref, and Hemi_Alt were added for JGA-WGS, JGA-SNP, and NCBN.
-            li
-              strong Advanced Search:
-              |  Search conditions can now be shared in the URL and restored with the browser Back and Forward buttons.
-            li
-              strong Search results:
-              |  In addition to showing or hiding columns, you can now reorder them by dragging and dropping items in the column menu.
-            li
-              strong Downloads:
-              |  A tabix-indexed TSV representation containing JSON annotations was added for GRCh37 and GRCh38. You can retrieve annotations for a specified region as JSON without first downloading an entire chromosome file. The conventional TSV representation remains available.
-            li
-              strong Terms of Use:
-              |  The license for TogoVar-original materials was changed from
-              |
-              a.hyper-text.-external(target='_blank', href='https://opendatacommons.org/licenses/odbl/summary/') ODbL 1.0
-              |  to
-              |
-              a.hyper-text.-internal(href='/doc/terms#togovar-license') CC BY 4.0
-              | . Terms specified by each provider continue to apply to third-party data.
-          h3.sectiontitle.heading
-            span.date 2025/6/4
-            span.number Release: 2025.1
-          ul.unordered-list.items
-            li
-              strong Gene page:
-              |  #[a.hyper-text.-external(href='https://molossinus.brc.riken.jp/mogplus/') MoG+ (Mouse genome database with high added value)] was newly added.
-              ul.unordered-list
-                li
-                  | Mappings between mouse variants in MoG+ and human variants in TogoVar are now available on gene pages (e.g.,
-                  |
-                  a.hyper-text.-internal(href='/gene/1101#mouse-variants-in-mogplus-database') BRCA2
-                  | ).
-                li The mappings are based on the
-                  |
-                  |
-                  a.hyper-text.-external(href='https://hgdownload.soe.ucsc.edu/goldenPath/hg38/liftOver/') UCSC Chain File (hg38ToMm39.over.chain.gz)
-                  | .
-                li You can now search for laboratory mouse strains that carry variants corresponding to human missense or pathogenic variants.
-                li MoG+ is developed and operated by
-                  |
-                  |
-                  a.hyper-text.-external(href='https://web.brc.riken.jp/en/') RIKEN BioResource Research Center
-                  | .
-            li
-              strong Gene page:
-              |
-              | Protein Browser was newly added to the gene pages.
-              ul.unordered-list
-                li  The following data are aligned along an amino acid sequence to facilitate comparison: (e.g.,
-                  |
-                  |
-                  a.hyper-text.-internal(href='/gene/1101#protein-browser') BRCA2
-                  | ):
-                  ul.unordered-list
-                    li Missense variants and their pathogenicity (Source: TogoVar)
-                    li Phosphorylation sites (Source:
-                      |
-                      |
-                      a.hyper-text.-external(href='https://jpostdb.org/') jPOST: Japan ProteOme STandard Repository/Database
-                      | )
-                    li Glycosylation sites (Source:
-                      |
-                      |
-                      a.hyper-text.-external(href='https://glycosmos.org/') GlyCosmos: Glycoscience Portal
-                      | )
-                    li Disease-associated variants (Source: UniProt)
-            li
-              strong Variant/Gene page:
-              |
-              | New URL formats are now supported.
-              ul.unordered-list
-                li By chromosome number, position, reference allele, and alternate allele:
-                  ul.unordered-list
-                    li Example:
-                      |
-                      |
-                      a.hyper-text.-internal(href='/variant/12-111803962-G-A') https://grch38.togovar.org/variant/12-111803962-G-A
-                li By dbSNP rs number:
-                  ul.unordered-list
-                    li Example:
-                      |
-                      |
-                      a.hyper-text.-internal(href='/variant/rs671') https://grch38.togovar.org/variant/rs671
-                li By HGNC gene symbol:
-                  ul.unordered-list
-                    li Example:
-                      |
-                      |
-                      a.hyper-text.-internal(href='/gene/ALDH2') https://grch38.togovar.org/gene/ALDH2
-          h3.sectiontitle.heading
-            span.date 2024/12/3
-            span.number Release: 2024.2
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |
-              | Clinical significance from
-              |
-              a.hyper-text.-external(href='https://mgend.jihs.go.jp/') MGeND (Medical Genomics Japan Variant Database)
-              |
-              | was newly added.
-              ul.unordered-list
-                li MGeND is a database of genome variants and their clinical characteristics, 
-                  | collected through
-                  |
-                  a.hyper-text.-external(href='https://www.amed.go.jp/en/program/list/14/05/006.html') the Clinical Genome Information Integration Database Development Project
-                  |
-                  | by the Japan Agency for Medical Research and Development (AMED).
-                  | MGeND contains variant information for diseases such as cancer, rare and intractable diseases, infectious diseases, dementia, and hearing loss,
-                  | and can be considered the Japanese equivalent of ClinVar. 
-                li The disease names in MGeND have been aligned with the vocabulary defined in
-                  |
-                  |
-                  a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen') MedGen
-                  | , which is also used in ClinVar, wherever possible.
-            li
-              strong Datasets:
-              |
-              | Added datasets derived from JGA and renamed some of them.
-              ul.unordered-list
-                li We reanalyzed whole-genome sequences deposited in the
-                  |
-                  |
-                  a.hyper-text.-external(href='https://humandbs.dbcls.jp/en/') NBDC Human Database
-                  | /
-                  a.hyper-text.-external(href='https://www.ddbj.nig.ac.jp/jga/index-e.html') Japanese Genotype-phenotype Archive (JGA)
-                  | , aggregated allele frequencies and genotype counts, and released them as
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/jga_wgs') JGA-WGS
-                  | . The reference genome used is GRCh38. For more information on the reanalysis, please refer to
-                  |
-                  a.hyper-text.-external(href='https://humandbs.dbcls.jp/en/whole-genome-sequencing') “Whole genome sequencing data processing (germline)”
-                  |
-                  | on the NBDC Human Database website.
-                li The frequencies previously published as JGA-NGS, obtained by variant calling on whole-exome sequences deposited to JGA, were renamed to
-                  |
-                  |
-                  a.hyper-text.-internal(href='/doc/datasets/jga_wes') JGA-WES
-                  | .
-            li
-              strong Gene page:
-              |
-              | Missense variants are visualized on a 3D protein structure.
-              ul.unordered-list
-                li The visualization helps you to assess the potential impact of each missense variant on a protein structure (e.g.,
-                  |
-                  |
-                  a.hypertext.-external(href='/gene/1097#protein-structure') BRAF:p.V600E
-                  | ,
-                  |
-                  a.hypertext.-external(href='/gene/6407#protein-structure') KRAS:p.G12D
-                  | ).
-                li You can choose from protein structures registered in
-                  |
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://pdbj.org/?lang=en') Protein Data Bank Japan (PDBj)
-                  |
-                  | or those predicted by
-                  |
-                  a.hyper-text.-external(target='_blank', href='https://alphafold.ebi.ac.uk/') AlphaFold
-                  | . Please note that the displayed structures do not account for the effects of the variant.
-          h3.sectiontitle.heading
-            span.date 2024/6/27
-            span.number Release: 2024.1
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |
-              | Allele frequencies and genotype counts (by disease and sex) for
-              |
-              |
-              a.hyper-text.-internal(href='datasets/jga_snp#diseases_jgad000123') 45 diseases
-              |
-              | were added to
-              |
-              a.hyper-text.-internal(href='datasets/jga_snp') JGA-SNP
-              |
-              | as disease-specific information.
-              ul.unordered-list
-                li
-                  a.hyper-text.-external(href='https://biobankjp.org/en/') BioBank Japan
-                  |  and
-                  |
-                  a.hyper-text.-external(href='https://www.ims.riken.jp/english/') RIKEN
-                  |  collected samples and performed genotyping by SNP array for 182,557 individuals.
-                li The frequency can be displayed by expanding the “Section: Frequency” &gt; “Dataset: "JGA-SNP” &gt; “Population: Total” on each variant report page (e.g.,
-                  |
-                  |
-                  a.hyper-text.-internal(href='/variant/tgv66359566#frequency') tgv66359566
-                  | ). You can search for variants based on the disease and sex-specific frequencies using the “Alternate allele frequency/count” in the Advanced search.
-            li
-              strong Datasets:
-              |
-              | Allele frequencies and genotype counts of 9,290 Japanese were newly added as
-              |
-              |
-              a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/ncbn') NCBN dataset
-              |  (GRCh38 only).
-              ul.unordered-list
-                li
-                  a.hyper-text.-external(href='https://ncbiobank.org/en/') The National Center BioBank Network (NCBN)
-                  |
-                  | collected the samples and conducted whole-genome analysis.
-                li The Japanese frequencies can be compared with those of the 2,504 individuals from
-                  |
-                  |
-                  a.hyper-text.-external(href='https://www.internationalgenome.org/') the international 1000 Genomes Project (1KGP)
-                  |. Joint calling was performed for the Japanese and 1KGP samples.
-                li The frequency can be displayed by expanding the “Section: Frequency” &gt; “Dataset: NCBN” &gt; “Population: Total” on each variant report page (e.g.,
-                  |
-                  |
-                  a.hyper-text.-internal(href='/variant/tgv80918483#frequency') tgv80918483
-                  | ).
-                  | You can search for variants based on the population-specific frequencies using the “Alternate allele frequency/count” in the Advanced search.
-          h3.sectiontitle.heading 2024/2/28
-          ul.unordered-list.items
-            li
-              strong Simple/Advanced search:
-              |
-              | Pathogenicity predictions with
-              |
-              a.hyper-text.-external(href='https://github.com/google-deepmind/alphamissense') AlphaMissense
-              |
-              | (
-              a.hyper-text.-external(href='https://www.science.org/doi/10.1126/science.adg7492') Cheng et al.2023
-              | ) were added to the missense variants in TogoVar.
-            li
-              strong Datasets:
-              |
-              |
-              a.hyper-text.-external(href='https://gnomad.broadinstitute.org/') The Genome Aggregation Database (gnomAD)
-              |
-              | was updated to version 4.0.
-          h3.sectiontitle.heading 2023/11/16
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |
-              |
-              | ToMMo 14KJPN was updated to ToMMo 54KJPN (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall')
-                | ToMMo 54KJPN-SNV/INDEL Allele Frequency Panel (v20230626)
-              | ).
-            li
-              strong Advanced search:
-              |
-              | You can search by TogoVar ID (e.g. tgv47264307) or dbSNP refSNP ID (e.g. rs671).
-            li
-              strong Downloads:
-              |
-              | Allele frequencies for all variants are available in
-              |
-              a.hyper-text.-external(href='https://samtools.github.io/hts-specs/VCFv4.4.pdf')
-                | VCF format
-              |  as well as tab-separated format.
-          h3.sectiontitle.heading 2023/7/14
-          ul.unordered-list.items
-            li
-              strong Simple/Advanced search:
-              |
-              | You can download search results in JSON, CSV, or TSV formats.
-            li
-              strong Advanced search:
-              |
-              | We added the "Disease" field to the "Add condition" menu. You can now search by disease names from
-              |
-              a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen/') MedGen
-              | . The search targets include diseases in the subconcepts of
-              |
-              a.hyper-text.-external(href='https://monarchinitiative.org/') the Mondo disease ontology
-              | .
-          h3.sectiontitle.heading 2022/11/1
-          ul.unordered-list.items
-            li
-              strong URL:
-              |
-              | The URL of TogoVar was changed from
-              |
-              a.hyper-text.-external(href='https://togovar.biosciencedbc.jp') https://togovar.biosciencedbc.jp
-              |
-              | to
-              |
-              a.hyper-text.-internal(href='https://togovar.org') https://togovar.org.
-            li
-              strong Simple/Advanced search:
-              |
-              | You can search variants by a location of the GRCh38 reference sequence. Search by a GRCh37 location is still available.
-              ul.unordererd-list
-                li
-                  a.hyper-text.-internal(href='https://grch38.togovar.org') https://grch38.togovar.org
-                  |
-                  | (GRCh38)
-                li
-                  a.hyper-text.-internal(href='https://grch37.togovar.org') https://grch37.togovar.org
-                  |
-                  | (GRCh37)
-            li
-              strong Downloads:
-              |
-              | Bulk download of the GRCh38-based variant data was made available in addition to the GRCh37-based one.
-              ul.unordererd-list
-                li
-                  a.hyper-text.-internal(href='https://grch38.togovar.org/downloads/release/current/grch38/') https://grch38.togovar.org/downloads/release/current/grch38/
-                  |
-                  | (GRCh38)
-                li
-                  a.hyper-text.-internal(href='https://grch37.togovar.org/downloads/release/current/grch37/') https://grch37.togovar.org/downloads/release/current/grch37/
-                  |
-                  | (GRCh37)
-            li
-              strong Misc:
-              |
-              | The provider of TogoVar was changed from
-              |
-              a.hyper-text.-external(href='https://biosciencedbc.jp') Department of NBDC Program, Japan Science and Technology Agency
-              |  to
-              |
-              a.hyper-text.-external(href='https://dbcls.rois.ac.jp') Database Center for Life Science, Joint Support-Center for Data Science Research, Research Organization of Information and Systems (DBCLS).
-          h3.sectiontitle.heading 2022/8/5
-          ul.unordered-list.items
-            li
-              strong Advanced search:
-              |  #[a.hyper-text.-internal(href='/?mode=advanced') Advanced search] was released.
-            li
-              strong Gene page/Disease page:
-              |
-              | Variant information pages related to a gene (e.g.,
-              a.hyper-text.-internal(href='/gene/8618') PAX4
-              |) or a disease (e.g.,
-              a.hyper-text.-internal(href='/disease/C0023467') Acute myeloid leukemia
-              |) were released.
-            li
-              strong Variant page/Gene page/Disease page:
-              |
-              | Genome-wide association studies from
-              |
-              a.hyper-text.-external(href='https://www.ebi.ac.uk/gwas/') GWAS Catalog
-              |  was added to the variant, gene and disease pages.
-            li
-              strong TogoVar API:
-              |  #[a.hyper-text.-internal(href='/api') TogoVar API version 0.91] was released.
-          h3.sectiontitle.heading 2021/12/16
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  ToMMo 4.7KJPN was updated to ToMMo 8.3KJPN (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-8.3kjpn-20200831-af_snvindelall') ToMMo 8.3KJPN Allele Frequency Panel).
-            li
-              strong Datasets:
-              |  ExAC was updated to gnomAD v2.1.1 (
-              a.hyper-text.-external(href='https://gnomad.broadinstitute.org/downloads') The Genome Aggregation Database).
-          h3.sectiontitle.heading 2020/10/22
-          ul.unordered-list.items
-            li
-              strong Keyword search:
-              |  You can search TogoVar by
-              |
-              a.hyper-text.-external(target='_blank', href='https://varnomen.hgvs.org/') Human Genome Variation Society (HGVS) description
-              |  (e.g. #[a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:c.1510G&gt;A] or #[a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:p.Glu504Lys]).
-          h3.sectiontitle.heading 2020/7/27
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  The new dataset,
-              |
-              a(href='/doc/datasets/gem_j_wga') GEM-Japan Whole Genome Aggregation (GEM-J WGA)
-              | , was added. Additionally, ToMMo 3.5KJPN was updated to ToMMo 4.7KJPN (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-4.7kjpn-20190826-af_snvindelall') ToMMo 4.7KJPN Allele Frequency Panel
-              | ). ClinVar information was also updated.
-            li
-              strong Usability:
-              |  You can search the variants on Karyotype image.
-          h3.sectiontitle.heading 2019/7/25
-          ul.unordered-list.items
-            li
-              strong Keyword search:
-              |  You can search TogoVar by an alias name of HGNC Gene Symbol (e.g. PD-1, p53).
-            li
-              strong Filters:
-              |  You can specify either all or any of datasets of your choice as a target when searching by
-              | an alternate allele frequency.
-            li
-              strong Filters:
-              |  You can filter variants by Consequence value, SIFT and/or Polyphen score.
-            li
-              strong Filters:
-              |  You can hide and show low quality variants.
-            li
-              strong Datasets:
-              |  ToMMo 3.5KJPN was updated to Ver.2 (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-ijgvd-3.5kjpnv1-af_snvindelall') ToMMo 3.5KJPNv2 Allele Frequency Panel
-              | ). ClinVar, Variant Effect Predictor (VEP) and Ensembl were updated as well. See
-              |
-              a(href='/doc/datasets') Datasets
-              |  for detail.
-            li
-              strong Usability:
-              |  You can choose the data items to display at the Configuration menu.
-            li
-              strong Usability:
-              |  The user interface was refined for easier use.
-          h3.sectiontitle.heading 2018/6/7
-          ul.unordered-list.items
-            li
-              | TogoVar has been released. See
-              |
-              a.hyper-text.-external(href='https://www.eurekalert.org/pub_releases/2018-07/jsat-jr071018.php')
-                | a EurekAlert! press release
-              |  for detail.
+          .release
+            h3.sectiontitle.heading
+              span.date 2026/8/X
+              span.number Release: 2026.1
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  New frequency datasets were added to GRCh38, and existing datasets were updated.
+                ul.unordered-list
+                  li
+                    | Allele frequencies and genotype counts for
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/bbj1k') BBJ1K
+                    |  (WGS of 1,026 BioBank Japan participants) and
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/bbj2k') BBJ2K
+                    |  (WGS of 1,964 BioBank Japan participants) were added to
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/jga_wgs') JGA-WGS
+                    |  as two datasets, bringing it to a total of six datasets and 3,068 individuals.
+                  li
+                    a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-jsv1-20211208-af') ToMMo JSV1
+                    | , a structural-variant frequency dataset based on long-read WGS of 222 Japanese individuals, was added.
+                  li
+                    | Alternate allele frequencies including structural variants derived from
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://jogo.csml.org/') JoGo 1.0
+                    | , a human gene haplotype database based on long-read WGS, were added.
+                  li
+                    | ToMMo 54KJPN was updated to
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-61kjpn-20250616-af_snvindelall') 61KJPN
+                    |  (61,424 individuals).
+              li
+                strong Simple/Advanced Search:
+                |  #[a.hyper-text.-external(target='_blank', href='https://cadd.bihealth.org/') CADD] (PHRED score) and predicted splicing types from #[a.hyper-text.-external(target='_blank', href='https://sscvdb.io/') SSCV DB] were added as search filters and result fields.
+              li
+                strong Advanced Search:
+                |  Genotype-count searches for Alt/Alt, Alt/Ref, and Hemi_Alt were added for JGA-WGS, JGA-SNP, and NCBN.
+              li
+                strong Advanced Search:
+                |  Search conditions can now be shared in the URL and restored with the browser Back and Forward buttons.
+              li
+                strong Search results:
+                |  In addition to showing or hiding columns, you can now reorder them by dragging and dropping items in the column menu.
+              li
+                strong Downloads:
+                |  A tabix-indexed TSV representation containing JSON annotations was added for GRCh37 and GRCh38. You can retrieve annotations for a specified region as JSON without first downloading an entire chromosome file. The conventional TSV representation remains available.
+              li
+                strong Terms of Use:
+                |  The license for TogoVar-original materials was changed from
+                |
+                a.hyper-text.-external(target='_blank', href='https://opendatacommons.org/licenses/odbl/summary/') ODbL 1.0
+                |  to
+                |
+                a.hyper-text.-internal(href='/doc/terms#togovar-license') CC BY 4.0
+                | . Terms specified by each provider continue to apply to third-party data.
+          .release
+            h3.sectiontitle.heading
+              span.date 2025/6/4
+              span.number Release: 2025.1
+            ul.unordered-list.items
+              li
+                strong Gene page:
+                |  #[a.hyper-text.-external(href='https://molossinus.brc.riken.jp/mogplus/') MoG+ (Mouse genome database with high added value)] was newly added.
+                ul.unordered-list
+                  li
+                    | Mappings between mouse variants in MoG+ and human variants in TogoVar are now available on gene pages (e.g.,
+                    |
+                    a.hyper-text.-internal(href='/gene/1101#mouse-variants-in-mogplus-database') BRCA2
+                    | ).
+                  li The mappings are based on the
+                    |
+                    |
+                    a.hyper-text.-external(href='https://hgdownload.soe.ucsc.edu/goldenPath/hg38/liftOver/') UCSC Chain File (hg38ToMm39.over.chain.gz)
+                    | .
+                  li You can now search for laboratory mouse strains that carry variants corresponding to human missense or pathogenic variants.
+                  li MoG+ is developed and operated by
+                    |
+                    |
+                    a.hyper-text.-external(href='https://web.brc.riken.jp/en/') RIKEN BioResource Research Center
+                    | .
+              li
+                strong Gene page:
+                |
+                | Protein Browser was newly added to the gene pages.
+                ul.unordered-list
+                  li  The following data are aligned along an amino acid sequence to facilitate comparison: (e.g.,
+                    |
+                    |
+                    a.hyper-text.-internal(href='/gene/1101#protein-browser') BRCA2
+                    | ):
+                    ul.unordered-list
+                      li Missense variants and their pathogenicity (Source: TogoVar)
+                      li Phosphorylation sites (Source:
+                        |
+                        |
+                        a.hyper-text.-external(href='https://jpostdb.org/') jPOST: Japan ProteOme STandard Repository/Database
+                        | )
+                      li Glycosylation sites (Source:
+                        |
+                        |
+                        a.hyper-text.-external(href='https://glycosmos.org/') GlyCosmos: Glycoscience Portal
+                        | )
+                      li Disease-associated variants (Source: UniProt)
+              li
+                strong Variant/Gene page:
+                |
+                | New URL formats are now supported.
+                ul.unordered-list
+                  li By chromosome number, position, reference allele, and alternate allele:
+                    ul.unordered-list
+                      li Example:
+                        |
+                        |
+                        a.hyper-text.-internal(href='/variant/12-111803962-G-A') https://grch38.togovar.org/variant/12-111803962-G-A
+                  li By dbSNP rs number:
+                    ul.unordered-list
+                      li Example:
+                        |
+                        |
+                        a.hyper-text.-internal(href='/variant/rs671') https://grch38.togovar.org/variant/rs671
+                  li By HGNC gene symbol:
+                    ul.unordered-list
+                      li Example:
+                        |
+                        |
+                        a.hyper-text.-internal(href='/gene/ALDH2') https://grch38.togovar.org/gene/ALDH2
+          .release
+            h3.sectiontitle.heading
+              span.date 2024/12/3
+              span.number Release: 2024.2
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |
+                | Clinical significance from
+                |
+                a.hyper-text.-external(href='https://mgend.jihs.go.jp/') MGeND (Medical Genomics Japan Variant Database)
+                |
+                | was newly added.
+                ul.unordered-list
+                  li MGeND is a database of genome variants and their clinical characteristics,
+                    | collected through
+                    |
+                    a.hyper-text.-external(href='https://www.amed.go.jp/en/program/list/14/05/006.html') the Clinical Genome Information Integration Database Development Project
+                    |
+                    | by the Japan Agency for Medical Research and Development (AMED).
+                    | MGeND contains variant information for diseases such as cancer, rare and intractable diseases, infectious diseases, dementia, and hearing loss,
+                    | and can be considered the Japanese equivalent of ClinVar.
+                  li The disease names in MGeND have been aligned with the vocabulary defined in
+                    |
+                    |
+                    a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen') MedGen
+                    | , which is also used in ClinVar, wherever possible.
+              li
+                strong Datasets:
+                |
+                | Added datasets derived from JGA and renamed some of them.
+                ul.unordered-list
+                  li We reanalyzed whole-genome sequences deposited in the
+                    |
+                    |
+                    a.hyper-text.-external(href='https://humandbs.dbcls.jp/en/') NBDC Human Database
+                    | /
+                    a.hyper-text.-external(href='https://www.ddbj.nig.ac.jp/jga/index-e.html') Japanese Genotype-phenotype Archive (JGA)
+                    | , aggregated allele frequencies and genotype counts, and released them as
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/jga_wgs') JGA-WGS
+                    | . The reference genome used is GRCh38. For more information on the reanalysis, please refer to
+                    |
+                    a.hyper-text.-external(href='https://humandbs.dbcls.jp/en/whole-genome-sequencing') “Whole genome sequencing data processing (germline)”
+                    |
+                    | on the NBDC Human Database website.
+                  li The frequencies previously published as JGA-NGS, obtained by variant calling on whole-exome sequences deposited to JGA, were renamed to
+                    |
+                    |
+                    a.hyper-text.-internal(href='/doc/datasets/jga_wes') JGA-WES
+                    | .
+              li
+                strong Gene page:
+                |
+                | Missense variants are visualized on a 3D protein structure.
+                ul.unordered-list
+                  li The visualization helps you to assess the potential impact of each missense variant on a protein structure (e.g.,
+                    |
+                    |
+                    a.hypertext.-external(href='/gene/1097#protein-structure') BRAF:p.V600E
+                    | ,
+                    |
+                    a.hypertext.-external(href='/gene/6407#protein-structure') KRAS:p.G12D
+                    | ).
+                  li You can choose from protein structures registered in
+                    |
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://pdbj.org/?lang=en') Protein Data Bank Japan (PDBj)
+                    |
+                    | or those predicted by
+                    |
+                    a.hyper-text.-external(target='_blank', href='https://alphafold.ebi.ac.uk/') AlphaFold
+                    | . Please note that the displayed structures do not account for the effects of the variant.
+          .release
+            h3.sectiontitle.heading
+              span.date 2024/6/27
+              span.number Release: 2024.1
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |
+                | Allele frequencies and genotype counts (by disease and sex) for
+                |
+                |
+                a.hyper-text.-internal(href='datasets/jga_snp#diseases_jgad000123') 45 diseases
+                |
+                | were added to
+                |
+                a.hyper-text.-internal(href='datasets/jga_snp') JGA-SNP
+                |
+                | as disease-specific information.
+                ul.unordered-list
+                  li
+                    a.hyper-text.-external(href='https://biobankjp.org/en/') BioBank Japan
+                    |  and
+                    |
+                    a.hyper-text.-external(href='https://www.ims.riken.jp/english/') RIKEN
+                    |  collected samples and performed genotyping by SNP array for 182,557 individuals.
+                  li The frequency can be displayed by expanding the “Section: Frequency” &gt; “Dataset: "JGA-SNP” &gt; “Population: Total” on each variant report page (e.g.,
+                    |
+                    |
+                    a.hyper-text.-internal(href='/variant/tgv66359566#frequency') tgv66359566
+                    | ). You can search for variants based on the disease and sex-specific frequencies using the “Alternate allele frequency/count” in the Advanced search.
+              li
+                strong Datasets:
+                |
+                | Allele frequencies and genotype counts of 9,290 Japanese were newly added as
+                |
+                |
+                a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets/ncbn') NCBN dataset
+                |  (GRCh38 only).
+                ul.unordered-list
+                  li
+                    a.hyper-text.-external(href='https://ncbiobank.org/en/') The National Center BioBank Network (NCBN)
+                    |
+                    | collected the samples and conducted whole-genome analysis.
+                  li The Japanese frequencies can be compared with those of the 2,504 individuals from
+                    |
+                    |
+                    a.hyper-text.-external(href='https://www.internationalgenome.org/') the international 1000 Genomes Project (1KGP)
+                    |. Joint calling was performed for the Japanese and 1KGP samples.
+                  li The frequency can be displayed by expanding the “Section: Frequency” &gt; “Dataset: NCBN” &gt; “Population: Total” on each variant report page (e.g.,
+                    |
+                    |
+                    a.hyper-text.-internal(href='/variant/tgv80918483#frequency') tgv80918483
+                    | ).
+                    | You can search for variants based on the population-specific frequencies using the “Alternate allele frequency/count” in the Advanced search.
+          .release
+            h3.sectiontitle.heading 2024/2/28
+            ul.unordered-list.items
+              li
+                strong Simple/Advanced search:
+                |
+                | Pathogenicity predictions with
+                |
+                a.hyper-text.-external(href='https://github.com/google-deepmind/alphamissense') AlphaMissense
+                |
+                | (
+                a.hyper-text.-external(href='https://www.science.org/doi/10.1126/science.adg7492') Cheng et al.2023
+                | ) were added to the missense variants in TogoVar.
+              li
+                strong Datasets:
+                |
+                |
+                a.hyper-text.-external(href='https://gnomad.broadinstitute.org/') The Genome Aggregation Database (gnomAD)
+                |
+                | was updated to version 4.0.
+          .release
+            h3.sectiontitle.heading 2023/11/16
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |
+                |
+                | ToMMo 14KJPN was updated to ToMMo 54KJPN (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall')
+                  | ToMMo 54KJPN-SNV/INDEL Allele Frequency Panel (v20230626)
+                | ).
+              li
+                strong Advanced search:
+                |
+                | You can search by TogoVar ID (e.g. tgv47264307) or dbSNP refSNP ID (e.g. rs671).
+              li
+                strong Downloads:
+                |
+                | Allele frequencies for all variants are available in
+                |
+                a.hyper-text.-external(href='https://samtools.github.io/hts-specs/VCFv4.4.pdf')
+                  | VCF format
+                |  as well as tab-separated format.
+          .release
+            h3.sectiontitle.heading 2023/7/14
+            ul.unordered-list.items
+              li
+                strong Simple/Advanced search:
+                |
+                | You can download search results in JSON, CSV, or TSV formats.
+              li
+                strong Advanced search:
+                |
+                | We added the "Disease" field to the "Add condition" menu. You can now search by disease names from
+                |
+                a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen/') MedGen
+                | . The search targets include diseases in the subconcepts of
+                |
+                a.hyper-text.-external(href='https://monarchinitiative.org/') the Mondo disease ontology
+                | .
+          .release
+            h3.sectiontitle.heading 2022/11/1
+            ul.unordered-list.items
+              li
+                strong URL:
+                |
+                | The URL of TogoVar was changed from
+                |
+                a.hyper-text.-external(href='https://togovar.biosciencedbc.jp') https://togovar.biosciencedbc.jp
+                |
+                | to
+                |
+                a.hyper-text.-internal(href='https://togovar.org') https://togovar.org.
+              li
+                strong Simple/Advanced search:
+                |
+                | You can search variants by a location of the GRCh38 reference sequence. Search by a GRCh37 location is still available.
+                ul.unordered-list
+                  li
+                    a.hyper-text.-internal(href='https://grch38.togovar.org') https://grch38.togovar.org
+                    |
+                    | (GRCh38)
+                  li
+                    a.hyper-text.-internal(href='https://grch37.togovar.org') https://grch37.togovar.org
+                    |
+                    | (GRCh37)
+              li
+                strong Downloads:
+                |
+                | Bulk download of the GRCh38-based variant data was made available in addition to the GRCh37-based one.
+                ul.unordered-list
+                  li
+                    a.hyper-text.-internal(href='https://grch38.togovar.org/downloads/release/current/grch38/') https://grch38.togovar.org/downloads/release/current/grch38/
+                    |
+                    | (GRCh38)
+                  li
+                    a.hyper-text.-internal(href='https://grch37.togovar.org/downloads/release/current/grch37/') https://grch37.togovar.org/downloads/release/current/grch37/
+                    |
+                    | (GRCh37)
+              li
+                strong Misc:
+                |
+                | The provider of TogoVar was changed from
+                |
+                a.hyper-text.-external(href='https://biosciencedbc.jp') Department of NBDC Program, Japan Science and Technology Agency
+                |  to
+                |
+                a.hyper-text.-external(href='https://dbcls.rois.ac.jp') Database Center for Life Science, Joint Support-Center for Data Science Research, Research Organization of Information and Systems (DBCLS).
+          .release
+            h3.sectiontitle.heading 2022/8/5
+            ul.unordered-list.items
+              li
+                strong Advanced search:
+                |  #[a.hyper-text.-internal(href='/?mode=advanced') Advanced search] was released.
+              li
+                strong Gene page/Disease page:
+                |
+                | Variant information pages related to a gene (e.g.,
+                a.hyper-text.-internal(href='/gene/8618') PAX4
+                |) or a disease (e.g.,
+                a.hyper-text.-internal(href='/disease/C0023467') Acute myeloid leukemia
+                |) were released.
+              li
+                strong Variant page/Gene page/Disease page:
+                |
+                | Genome-wide association studies from
+                |
+                a.hyper-text.-external(href='https://www.ebi.ac.uk/gwas/') GWAS Catalog
+                |  was added to the variant, gene and disease pages.
+              li
+                strong TogoVar API:
+                |  #[a.hyper-text.-internal(href='/api') TogoVar API version 0.91] was released.
+          .release
+            h3.sectiontitle.heading 2021/12/16
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  ToMMo 4.7KJPN was updated to ToMMo 8.3KJPN (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-8.3kjpn-20200831-af_snvindelall') ToMMo 8.3KJPN Allele Frequency Panel).
+              li
+                strong Datasets:
+                |  ExAC was updated to gnomAD v2.1.1 (
+                a.hyper-text.-external(href='https://gnomad.broadinstitute.org/downloads') The Genome Aggregation Database).
+          .release
+            h3.sectiontitle.heading 2020/10/22
+            ul.unordered-list.items
+              li
+                strong Keyword search:
+                |  You can search TogoVar by
+                |
+                a.hyper-text.-external(target='_blank', href='https://varnomen.hgvs.org/') Human Genome Variation Society (HGVS) description
+                |  (e.g. #[a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:c.1510G&gt;A] or #[a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:p.Glu504Lys]).
+          .release
+            h3.sectiontitle.heading 2020/7/27
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  The new dataset,
+                |
+                a(href='/doc/datasets/gem_j_wga') GEM-Japan Whole Genome Aggregation (GEM-J WGA)
+                | , was added. Additionally, ToMMo 3.5KJPN was updated to ToMMo 4.7KJPN (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-4.7kjpn-20190826-af_snvindelall') ToMMo 4.7KJPN Allele Frequency Panel
+                | ). ClinVar information was also updated.
+              li
+                strong Usability:
+                |  You can search the variants on Karyotype image.
+          .release
+            h3.sectiontitle.heading 2019/7/25
+            ul.unordered-list.items
+              li
+                strong Keyword search:
+                |  You can search TogoVar by an alias name of HGNC Gene Symbol (e.g. PD-1, p53).
+              li
+                strong Filters:
+                |  You can specify either all or any of datasets of your choice as a target when searching by
+                | an alternate allele frequency.
+              li
+                strong Filters:
+                |  You can filter variants by Consequence value, SIFT and/or Polyphen score.
+              li
+                strong Filters:
+                |  You can hide and show low quality variants.
+              li
+                strong Datasets:
+                |  ToMMo 3.5KJPN was updated to Ver.2 (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-ijgvd-3.5kjpnv1-af_snvindelall') ToMMo 3.5KJPNv2 Allele Frequency Panel
+                | ). ClinVar, Variant Effect Predictor (VEP) and Ensembl were updated as well. See
+                |
+                a(href='/doc/datasets') Datasets
+                |  for detail.
+              li
+                strong Usability:
+                |  You can choose the data items to display at the Configuration menu.
+              li
+                strong Usability:
+                |  The user interface was refined for easier use.
+          .release
+            h3.sectiontitle.heading 2018/6/7
+            ul.unordered-list.items
+              li
+                | TogoVar has been released. See
+                |
+                a.hyper-text.-external(href='https://www.eurekalert.org/pub_releases/2018-07/jsat-jr071018.php')
+                  | a EurekAlert! press release
+                |  for detail.

--- a/app/frontend/views/doc/ja/history.pug
+++ b/app/frontend/views/doc/ja/history.pug
@@ -17,350 +17,364 @@ block content
       .contents
         section.section.timeline
           //- リリース日が確定したら「X」を置き換える。
-          h3.sectiontitle.heading
-            span.date 2026/8/X
-            span.number リリース: 2026.1
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  GRCh38版に新しい頻度データセットを追加し、既存データセットを更新しました。
-              ul.unordered-list
-                li
-                  a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/jga_wgs') JGA-WGS
-                  | に、
-                  a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/bbj1k') BBJ1K
-                  | （バイオバンク・ジャパンの1,026名のWGS）および
-                  a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/bbj2k') BBJ2K
-                  | （同1,964名のWGS）のアレル頻度・ジェノタイプ数を2データセットとして追加し、合計6データセット、3,068名としました。
-                li
-                  a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-jsv1-20211208-af') ToMMo JSV1
-                  | （長鎖型WGSによる日本人222名の構造多型頻度）を追加しました。
-                li
-                  a.hyper-text.-external(target='_blank', href='https://jogo.csml.org/') JoGo 1.0
-                  | （長鎖型WGSに基づくヒト遺伝子ハプロタイプデータベース）由来の構造多型を含む代替アレル頻度を追加しました。
-                li
-                  | ToMMo 54KJPNを
-                  a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-61kjpn-20250616-af_snvindelall') 61KJPN
-                  | （61,424名）へ更新しました。
-            li
-              strong Simple/Advanced Search:
-              |  #[a.hyper-text.-external(target='_blank', href='https://cadd.bihealth.org/') CADD]（PHRED score）と
-              a.hyper-text.-external(target='_blank', href='https://sscvdb.io/') SSCV DB
-              | の予測スプライシングタイプを、検索条件および検索結果の表示項目に追加しました。
-            li
-              strong Advanced Search:
-              |  JGA-WGS、JGA-SNP、NCBNを対象に、Alt/Alt・Alt/Ref・Hemi_Altのジェノタイプ数による検索を追加しました。
-            li
-              strong Advanced Search:
-              |  検索条件をURLで共有できるようにし、ブラウザの「戻る」「進む」から検索条件と結果を復元できるようにしました。
-            li
-              strong Search results:
-              |  列の表示・非表示に加え、列選択メニュー内のドラッグ＆ドロップで表示順を変更できるようにしました。
-            li
-              strong Downloads:
-              |  GRCh37およびGRCh38のアノテーションデータにJSONを格納したtabix対応TSVを追加しました。染色体ごとのファイル全体を事前にダウンロードせず、指定した領域のアノテーションをJSONとして取得できます。従来のTSV形式も引き続き提供します。
-            li
-              strong Terms of Use:
-              |  TogoVar独自部分のライセンスを
-              a.hyper-text.-external(target='_blank', href='https://opendatacommons.org/licenses/odbl/summary/') ODbL 1.0
-              | から
-              a.hyper-text.-internal(href='/doc/ja/terms#togovar-license') CC BY 4.0
-              | へ変更しました。第三者由来データには、引き続き各提供元の利用条件が適用されます。
-          h3.sectiontitle.heading
-            span.date 2025/6/4
-            span.number リリース: 2025.1
-          ul.unordered-list.items
-            li
-              strong Gene page:
-              |  #[a.hyper-text.-external(href='https://molossinus.brc.riken.jp/mogplus/') MoG+ (Mouse genome database with high added value)]を新たに追加しました。
-              ul.unordered-list
-                li
-                  | MoG+に登録されているマウスバリアントとTogoVarのヒトバリアントとの対応関係を、遺伝子ページ（例：
-                  a.hyper-text.-internal(href='/gene/1101#mouse-variants-in-mogplus-database') BRCA2
-                  | ）に掲載しました。
-                li
-                  | 対応関係は、
-                  a.hyper-text.-external(href='https://hgdownload.soe.ucsc.edu/goldenPath/hg38/liftOver/') UCSC Chain File（hg38ToMm39.over.chain.gz）
-                  | に基づいています。
-                li
-                  | ヒトのミスセンスバリアントや病原性バリアントに対応するマウスバリアントを持つ実験マウス系統の探索が可能になりました。
-                li
-                  | MoG+は、
-                  a.hyper-text.-external(href='https://web.brc.riken.jp/ja/') 理化学研究所バイオリソース研究センター
-                  | により開発・運用されています。
-
-            li
-              strong Gene page:
-              |  Protein Browser を遺伝子ページに新たに追加しました。
-              ul.unordered-list
-                li
-                  | 以下のデータが比較しやすいようにアミノ酸配列上に整列表示されています（例：
-                  a.hyper-text.-internal(href='/gene/1101#protein-browser') BRCA2
-                  | ）：
-                  ul.unordered-list
-                    li ミスセンスバリアントとその病原性（情報源：TogoVar）
-                    li リン酸化部位（情報源：
-                      a.hyper-text.-external(href='https://jpostdb.org/') jPOST: Japan ProteOme STandard Repository/Database
-                      | ）
-                    li 糖鎖結合部位（情報源：
-                      a.hyper-text.-external(href='https://glycosmos.org/') 糖鎖科学ポータル GlyCosmos
-                      | ）
-                    li 疾患関連バリアント（情報源：UniProt）
+          .release
+            h3.sectiontitle.heading
+              span.date 2026/8/X
+              span.number リリース: 2026.1
+            ul.unordered-list.items
               li
-                strong Variant/Gene page:
-                |  新しい URL 形式がサポートされました。
+                strong Datasets:
+                |  GRCh38版に新しい頻度データセットを追加し、既存データセットを更新しました。
                 ul.unordered-list
-                  li 染色体番号、塩基位置、参照アレル、代替アレルによる指定
+                  li
+                    a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/jga_wgs') JGA-WGS
+                    | に、
+                    a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/bbj1k') BBJ1K
+                    | （バイオバンク・ジャパンの1,026名のWGS）および
+                    a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/bbj2k') BBJ2K
+                    | （同1,964名のWGS）のアレル頻度・ジェノタイプ数を2データセットとして追加し、合計6データセット、3,068名としました。
+                  li
+                    a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-jsv1-20211208-af') ToMMo JSV1
+                    | （長鎖型WGSによる日本人222名の構造多型頻度）を追加しました。
+                  li
+                    a.hyper-text.-external(target='_blank', href='https://jogo.csml.org/') JoGo 1.0
+                    | （長鎖型WGSに基づくヒト遺伝子ハプロタイプデータベース）由来の構造多型を含む代替アレル頻度を追加しました。
+                  li
+                    | ToMMo 54KJPNを
+                    a.hyper-text.-external(target='_blank', href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-61kjpn-20250616-af_snvindelall') 61KJPN
+                    | （61,424名）へ更新しました。
+              li
+                strong Simple/Advanced Search:
+                |  #[a.hyper-text.-external(target='_blank', href='https://cadd.bihealth.org/') CADD]（PHRED score）と
+                a.hyper-text.-external(target='_blank', href='https://sscvdb.io/') SSCV DB
+                | の予測スプライシングタイプを、検索条件および検索結果の表示項目に追加しました。
+              li
+                strong Advanced Search:
+                |  JGA-WGS、JGA-SNP、NCBNを対象に、Alt/Alt・Alt/Ref・Hemi_Altのジェノタイプ数による検索を追加しました。
+              li
+                strong Advanced Search:
+                |  検索条件をURLで共有できるようにし、ブラウザの「戻る」「進む」から検索条件と結果を復元できるようにしました。
+              li
+                strong Search results:
+                |  列の表示・非表示に加え、列選択メニュー内のドラッグ＆ドロップで表示順を変更できるようにしました。
+              li
+                strong Downloads:
+                |  GRCh37およびGRCh38のアノテーションデータにJSONを格納したtabix対応TSVを追加しました。染色体ごとのファイル全体を事前にダウンロードせず、指定した領域のアノテーションをJSONとして取得できます。従来のTSV形式も引き続き提供します。
+              li
+                strong Terms of Use:
+                |  TogoVar独自部分のライセンスを
+                a.hyper-text.-external(target='_blank', href='https://opendatacommons.org/licenses/odbl/summary/') ODbL 1.0
+                | から
+                a.hyper-text.-internal(href='/doc/ja/terms#togovar-license') CC BY 4.0
+                | へ変更しました。第三者由来データには、引き続き各提供元の利用条件が適用されます。
+          .release
+            h3.sectiontitle.heading
+              span.date 2025/6/4
+              span.number リリース: 2025.1
+            ul.unordered-list.items
+              li
+                strong Gene page:
+                |  #[a.hyper-text.-external(href='https://molossinus.brc.riken.jp/mogplus/') MoG+ (Mouse genome database with high added value)]を新たに追加しました。
+                ul.unordered-list
+                  li
+                    | MoG+に登録されているマウスバリアントとTogoVarのヒトバリアントとの対応関係を、遺伝子ページ（例：
+                    a.hyper-text.-internal(href='/gene/1101#mouse-variants-in-mogplus-database') BRCA2
+                    | ）に掲載しました。
+                  li
+                    | 対応関係は、
+                    a.hyper-text.-external(href='https://hgdownload.soe.ucsc.edu/goldenPath/hg38/liftOver/') UCSC Chain File（hg38ToMm39.over.chain.gz）
+                    | に基づいています。
+                  li
+                    | ヒトのミスセンスバリアントや病原性バリアントに対応するマウスバリアントを持つ実験マウス系統の探索が可能になりました。
+                  li
+                    | MoG+は、
+                    a.hyper-text.-external(href='https://web.brc.riken.jp/ja/') 理化学研究所バイオリソース研究センター
+                    | により開発・運用されています。
+
+              li
+                strong Gene page:
+                |  Protein Browser を遺伝子ページに新たに追加しました。
+                ul.unordered-list
+                  li
+                    | 以下のデータが比較しやすいようにアミノ酸配列上に整列表示されています（例：
+                    a.hyper-text.-internal(href='/gene/1101#protein-browser') BRCA2
+                    | ）：
                     ul.unordered-list
-                      li 例：
-                        a.hyper-text.-internal(href='/variant/12-111803962-G-A') https://grch38.togovar.org/variant/12-111803962-G-A
-                  li dbSNPのrs番号による指定
-                    ul.unordered-list
-                      li 例：
-                        a.hyper-text.-internal(href='/variant/rs671') https://grch38.togovar.org/variant/rs671
-                  li HGNC遺伝子シンボルによる指定
-                    ul.unordered-list
-                      li 例：
-                        a.hyper-text.-internal(href='/gene/ALDH2') https://grch38.togovar.org/gene/ALDH2
-          h3.sectiontitle.heading
-            span.date 2024/12/3
-            span.number リリース: 2024.2
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  #[a.hyper-text.-external(href='https://mgend.jihs.go.jp/') MGeND (Medical Genomics Japan Variant Database)]からの臨床的意義を新たに追加しました。
-              ul.unordered-list
-                li MGeNDは日本医療研究開発機構（AMED）の
-                  a.hyper-text.-external(href='https://www.amed.go.jp/program/list/14/05/006.html') 臨床ゲノム情報統合データベース整備事業
-                  | によって収集されたゲノムバリアントおよびそれらの臨床的特性のデータベースです。
-                  | このデータベースには、がん、希少・難治性疾患、感染症、認知症、難聴といった疾患のバリアント情報が含まれており、ClinVarの日本版に相当します。
-                  | 
-                li MGeNDの疾患名をClinVarで使用している
-                  a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen') MedGen
-                  | の語彙にできる限りマッピングしました。
-            li
-              strong Datasets:
-              |  JGA由来のデータセットを追加、一部名称を変更しました。
-              ul.unordered-list
+                      li ミスセンスバリアントとその病原性（情報源：TogoVar）
+                      li リン酸化部位（情報源：
+                        a.hyper-text.-external(href='https://jpostdb.org/') jPOST: Japan ProteOme STandard Repository/Database
+                        | ）
+                      li 糖鎖結合部位（情報源：
+                        a.hyper-text.-external(href='https://glycosmos.org/') 糖鎖科学ポータル GlyCosmos
+                        | ）
+                      li 疾患関連バリアント（情報源：UniProt）
                 li
-                  a.hyper-text.-external(href='https://humandbs.dbcls.jp/') NBDCヒトデータベース
-                  | /
-                  a.hyper-text.-external(href='https://www.ddbj.nig.ac.jp/jga/index.html') Japanese Genotype-phenotype Archive(JGA)
-                  | に寄託された全ゲノム配列を再解析し、アレル頻度やジェノタイプ数を集約し、JGA-WGSとして公開しました。参照ゲノムはGRCh38です。再解析の詳細については
-                  | NBDCヒトデータベースの
-                  a.hyper-text.-external(href='https://humandbs.dbcls.jp/whole-genome-sequencing') 「生殖系列の全ゲノムシークエンスデータの加工」
-                  | をご覧ください。
-                li JGAに寄託された全エクソーム配列の再解析により得られたアレル頻度データセットの名称をJGA-NGSから
-                  a.hyper-text.-internal(href='/doc/ja/datasets/jga_wes') JGA-WES
-                  | に変更しました。
-            li
-              strong Gene page:
-              |  ミスセンスバリアントをタンパク質の立体構造上に可視化しました。
-              ul.unordered-list
-                li ミスセンスバリアントがタンパク質の立体構造に及ぼす影響の把握を支援します（例：
-                  a.hypertext.-internal(href='/gene/1097#protein-structure') BRAF:p.V600E
-                  | 、
-                  a.hypertext.-internal(href='/gene/6407#protein-structure') KRAS:p.G12D
-                  | )
-                li
-                  a.hyper-text.-external(href='https://pdbj.org/?lang=ja') Protein Data Bank Japan (PDBj)
-                  |
-                  | に登録されている構造または
-                  a.hyper-text.-external(href='https://alphafold.ebi.ac.uk/') AlphaFold
-                  | で予測した構造を選択できます。なお、表示される構造にはバリアントの影響は考慮されていません。
-          h3.sectiontitle.heading
-            span.date 2024/6/27
-            span.number リリース: 2024.1
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  #[a.hyper-text.-internal(href='datasets/jga_snp#diseases_jgad000123') 45疾患]のアレル頻度およびgenotype count（疾患別ならびに男女別）を、疾患ごとの情報として
-              a.hyper-text.-internal(href='datasets/jga_snp') JGA-SNP
-              |
-              | に追加しました。
-              ul.unordered-list
-                li
-                  a.hyper-text.-external(href='https://biobankjp.org/') バイオバンク・ジャパン
-                  | と
-                  a.hyper-text.-external(href='https://www.ims.riken.jp/') 理化学研究所
-                  | がサンプルの収集と182,557人のSNPアレイによるジェノタイピングを実施しました。
-                li 頻度は各バリアントレポートページの「Frequency」&gt; Dataset「JGA-SNP」&gt; Population「Total」を展開すると表示できます（
-                  a.hyper-text.-internal(href='/variant/tgv66359566#frequency') tgv66359566の例
-                  | )。Advanced searchの「Alternate allele frequency/count」では疾患および性別毎のアレル頻度を条件にバリアントを検索できます。
-            li
-              strong Datasets:
-              |  9,290人の日本人のアレル頻度およびgenotype countを
-              a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/ncbn') NCBNデータセット
-              | として新たに追加しました（GRCh38のみ）。
-              ul.unordered-list
-                li
-                  a.hyper-text.-external(href='https://ncbiobank.org/') ナショナルセンター・バイオバンクネットワーク(NCBN)
-                  | がサンプルの収集と全ゲノム解析を実施しました。
-                li 日本人集団の頻度は
-                  a.hyper-text.-external(href='https://www.internationalgenome.org/') 国際1000ゲノムプロジェクト(1KGP)
-                  | の2,504人の頻度と比較できます。日本人集団と1KGPのジョイントコーリングが実施されました。
-                li 頻度は各バリアントレポートページの「frequency」&gt; Dataset「NCBN」 &gt; Population「Total」を展開すると表示できます (
-                  a.hyper-text.-internal(href='/variant/tgv80918483#frequency') tgv80918483の例
-                  | )。Advanced searchの「Alternate allele frequency/count」では集団別の頻度を条件にバリアントを検索できます。
-          h3.sectiontitle.heading 2024/2/28
-          ul.unordered-list.items
-            li
-              strong Simple/Advanced search:
-              |  #[a.hyper-text.-external(href='https://github.com/google-deepmind/alphamissense') AlphaMissense](
-              a.hyper-text.-external(href='https://www.science.org/doi/10.1126/science.adg7492') Cheng et al.2023
-              | )によるミスセンスバリアントの病原性予測結果を付与しました。
-            li
-              strong Datasets:
-              |  #[a.hyper-text.-external(href='https://gnomad.broadinstitute.org/') Genome Aggregation Database (gnomAD)]をバージョン4.0に更新しました。
-          h3.sectiontitle.heading 2023/11/16
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  ToMMo 14KJPNをToMMo 54KJPN (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall') ToMMo 54KJPN Allele Frequency Panel
-              | )に更新しました。
-            li
-              strong Advanced search:
-              |  バリアントID（例：tgv47264307(TogoVar)、rs671(dbSNP)）で検索可能になりました。
-            li
-              strong Downloads:
-              |  全バリアントのアレル頻度がこれまでのタブ区切り形式に加え、
-              a.hyper-text.-external(href='https://samtools.github.io/hts-specs/VCFv4.4.pdf')
-                | VCF形式
-              | でダウンロードできるようになりました。
-          h3.sectiontitle.heading 2023/7/14
-          ul.unordered-list.items
-            li
-              strong Simple/Advanced search:
-              |  検索結果をJSON、CSV、TSV形式でダウンロードできるようになりました。
-            li
-              strong Advanced search:
-              |  Add conditionに疾患名(Disease)を追加しました。
-              a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen/') MedGen
-              | の疾患名で検索できます。検索対象には疾患オントロジー
-              a.hyper-text.-external(href='https://monarchinitiative.org/') Mondo
-              | 上の下位概念の疾患も含まれます。
-          h3.sectiontitle.heading 2022/11/1
-          ul.unordered-list.items
-            li
-              strong URL:
-              |  TogoVarのURLが
-              a.hyper-text.-external(href='https://togovar.biosciencedbc.jp') https://togovar.biosciencedbc.jp
-              | から
-              a.hyper-text.-internal(href='https://togovar.org') https://togovar.org
-              | に変わりました。
-            li
-              strong Simple/Advanced search:
-              |  GRCh38の位置でもバリアントを検索できるようになりました。引き続きGRCh37の位置でも検索できます。
-              ul.unordererd-list
-                li
-                  a.hyper-text.-internal(href='https://grch38.togovar.org') https://grch38.togovar.org
-                  |
-                  | (GRCh38)
-                li
-                  a.hyper-text.-internal(href='https://grch37.togovar.org') https://grch37.togovar.org
-                  |
-                  | (GRCh37)
-            li
-              strong Downloads:
-              |  GRCh37に加え、GRCh38ベースのバリアントデータも一括ダウンロードできるようになりました。
-              ul.unordererd-list
-                li
-                  a.hyper-text.-internal(href='https://grch38.togovar.org/downloads/release/current/grch38/') https://grch38.togovar.org/downloads/release/current/grch38/
-                  |
-                  | (GRCh38)
-                li
-                  a.hyper-text.-internal(href='https://grch37.togovar.org/downloads/release/current/grch37/') https://grch37.togovar.org/downloads/release/current/grch37/
-                  |
-                  | (GRCh37)
-            li
-              strong Misc:
-              |  TogoVarの提供者が
-              a.hyper-text.-external(href='https://biosciencedbc.jp') 国立研究開発法人科学技術振興機構 NBDC事業推進部
-              | から
-              a.hyper-text.-external(href='https://dbcls.rois.ac.jp') 大学共同利用機関法人 情報・システム研究機構 データサイエンス共同利用基盤施設ライフサイエンス統合データベースセンター（DBCLS）
-              | に変わりました。
-          h3.sectiontitle.heading 2022/8/5
-          ul.unordered-list.items
-            li
-              strong Advanced search:
-              |  #[a.hyper-text.-internal(href='/?mode=advanced') Advanced search]を公開しました。
-            li
-              strong Gene page/Disease page:
-              |  1遺伝子（例：
-              a.hyper-text.-internal(href='/gene/8618') PAX4
-              |）および1疾患（例：
-              a.hyper-text.-internal(href='/disease/C0023467') Acute myeloid leukemia 
-              |）に関連するバリアント情報のページを公開しました。
-            li
-              strong Variant page/Gene page/Disease page:
-              |  #[a.hyper-text.-external(href='https://www.ebi.ac.uk/gwas/') GWAS Catalog]に掲載されているゲノムワイド関連解析情報をバリアント、遺伝子、疾患のページに追加しました。
-            li
-              strong TogoVar API:
-              |  #[a.hyper-text.-internal(href='/api') TogoVar API version 0.91]を公開しました。
-          h3.sectiontitle.heading 2021/12/16
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  ToMMo 4.7KJPNをToMMo 8.3KJPN (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-8.3kjpn-20200831-af_snvindelall') ToMMo 8.3KJPN Allele Frequency Panel
-              | )に更新しました。
-            li
-              strong Datasets:
-              |  ExACをgnomAD v2.1.1 (
-              a.hyper-text.-external(href='https://gnomad.broadinstitute.org/downloads') The Genome Aggregation Database
-              | )に更新しました。
-          h3.sectiontitle.heading 2020/10/22
-          ul.unordered-list.items
-            li
-              strong Keyword search:
-              |  #[a.hyper-text.-external(target='_blank', href='https://varnomen.hgvs.org/') Human Genome Variation Society (HGVS) 表記](例：
-              a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:c.1510G&gt;A
-              | 、
-              a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:p.Glu504Lys
-              | )で検索可能になりました。
-          h3.sectiontitle.heading 2020/7/27
-          ul.unordered-list.items
-            li
-              strong Datasets:
-              |  新たなデータセットとしてGEM-J WGA (
-              a(href='/doc/ja/datasets/gem_j_wga') GEM-Japan Whole Genome Aggregation
-              | )を追加し、ToMMo 3.5KJPNをToMMo 4.7KJPN (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-4.7kjpn-20190826-af_snvindelall') ToMMo 4.7KJPN Allele Frequency Panel
-              | )に更新しました。また、ClinVarも更新しました。
-            li
-              strong Usability:
-              |  Karyotypeによる検索ができるようになりました。
-          h3.sectiontitle.heading 2019/7/25
-          ul.unordered-list.items
-            li
-              strong Keyword search:
-              |  HGNC Gene Symbolの別名（例：PD-1、p53）で検索できるようになりました。
-            li
-              strong Filters:
-              |  Alternate allele frequencyを検索条件にする場合に、検索対象としてユーザーが選択した「全てのDataset」または「いずれかのDataset」のどちらかを指定できるようになりました。
-            li
-              strong Filters:
-              |  Consequence、SIFT、Polyphenの値でファセット検索可能になりました。
-            li
-              strong Filters:
-              |  低品質のバリアントを非表示にできるようになりました。
-            li
-              strong Datasets:
-              |  ToMMo 3.5KJPNをVer.2 (
-              a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-ijgvd-3.5kjpnv1-af_snvindelall') ToMMo 3.5KJPNv2 Allele Frequency Panel
-              | )に更新しました。ClinVar、Variant Effect Predictor (VEP)も更新しました。詳細は
-              a(href='/doc/ja/datasets') Datasets
-              | を参照ください。
-            li
-              strong Usability:
-              |  Configurationメニューで表示項目の選択ができるようになりました。
-            li
-              strong Usability:
-              |  ユーザーインターフェースを改善して使いやすくしました。
-          h3.sectiontitle.heading 2018/6/7
-          ul.unordered-list.items
-            li
-              | TogoVarの公開を開始しました。詳細は
-              a.hyper-text.-external(href='https://www.jst.go.jp/pr/announce/20180607/index.html') プレスリリース
-              | を参照ください。
+                  strong Variant/Gene page:
+                  |  新しい URL 形式がサポートされました。
+                  ul.unordered-list
+                    li 染色体番号、塩基位置、参照アレル、代替アレルによる指定
+                      ul.unordered-list
+                        li 例：
+                          a.hyper-text.-internal(href='/variant/12-111803962-G-A') https://grch38.togovar.org/variant/12-111803962-G-A
+                    li dbSNPのrs番号による指定
+                      ul.unordered-list
+                        li 例：
+                          a.hyper-text.-internal(href='/variant/rs671') https://grch38.togovar.org/variant/rs671
+                    li HGNC遺伝子シンボルによる指定
+                      ul.unordered-list
+                        li 例：
+                          a.hyper-text.-internal(href='/gene/ALDH2') https://grch38.togovar.org/gene/ALDH2
+          .release
+            h3.sectiontitle.heading
+              span.date 2024/12/3
+              span.number リリース: 2024.2
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  #[a.hyper-text.-external(href='https://mgend.jihs.go.jp/') MGeND (Medical Genomics Japan Variant Database)]からの臨床的意義を新たに追加しました。
+                ul.unordered-list
+                  li MGeNDは日本医療研究開発機構（AMED）の
+                    a.hyper-text.-external(href='https://www.amed.go.jp/program/list/14/05/006.html') 臨床ゲノム情報統合データベース整備事業
+                    | によって収集されたゲノムバリアントおよびそれらの臨床的特性のデータベースです。
+                    | このデータベースには、がん、希少・難治性疾患、感染症、認知症、難聴といった疾患のバリアント情報が含まれており、ClinVarの日本版に相当します。
+                    |
+                  li MGeNDの疾患名をClinVarで使用している
+                    a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen') MedGen
+                    | の語彙にできる限りマッピングしました。
+              li
+                strong Datasets:
+                |  JGA由来のデータセットを追加、一部名称を変更しました。
+                ul.unordered-list
+                  li
+                    a.hyper-text.-external(href='https://humandbs.dbcls.jp/') NBDCヒトデータベース
+                    | /
+                    a.hyper-text.-external(href='https://www.ddbj.nig.ac.jp/jga/index.html') Japanese Genotype-phenotype Archive(JGA)
+                    | に寄託された全ゲノム配列を再解析し、アレル頻度やジェノタイプ数を集約し、JGA-WGSとして公開しました。参照ゲノムはGRCh38です。再解析の詳細については
+                    | NBDCヒトデータベースの
+                    a.hyper-text.-external(href='https://humandbs.dbcls.jp/whole-genome-sequencing') 「生殖系列の全ゲノムシークエンスデータの加工」
+                    | をご覧ください。
+                  li JGAに寄託された全エクソーム配列の再解析により得られたアレル頻度データセットの名称をJGA-NGSから
+                    a.hyper-text.-internal(href='/doc/ja/datasets/jga_wes') JGA-WES
+                    | に変更しました。
+              li
+                strong Gene page:
+                |  ミスセンスバリアントをタンパク質の立体構造上に可視化しました。
+                ul.unordered-list
+                  li ミスセンスバリアントがタンパク質の立体構造に及ぼす影響の把握を支援します（例：
+                    a.hypertext.-internal(href='/gene/1097#protein-structure') BRAF:p.V600E
+                    | 、
+                    a.hypertext.-internal(href='/gene/6407#protein-structure') KRAS:p.G12D
+                    | )
+                  li
+                    a.hyper-text.-external(href='https://pdbj.org/?lang=ja') Protein Data Bank Japan (PDBj)
+                    |
+                    | に登録されている構造または
+                    a.hyper-text.-external(href='https://alphafold.ebi.ac.uk/') AlphaFold
+                    | で予測した構造を選択できます。なお、表示される構造にはバリアントの影響は考慮されていません。
+          .release
+            h3.sectiontitle.heading
+              span.date 2024/6/27
+              span.number リリース: 2024.1
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  #[a.hyper-text.-internal(href='datasets/jga_snp#diseases_jgad000123') 45疾患]のアレル頻度およびgenotype count（疾患別ならびに男女別）を、疾患ごとの情報として
+                a.hyper-text.-internal(href='datasets/jga_snp') JGA-SNP
+                |
+                | に追加しました。
+                ul.unordered-list
+                  li
+                    a.hyper-text.-external(href='https://biobankjp.org/') バイオバンク・ジャパン
+                    | と
+                    a.hyper-text.-external(href='https://www.ims.riken.jp/') 理化学研究所
+                    | がサンプルの収集と182,557人のSNPアレイによるジェノタイピングを実施しました。
+                  li 頻度は各バリアントレポートページの「Frequency」&gt; Dataset「JGA-SNP」&gt; Population「Total」を展開すると表示できます（
+                    a.hyper-text.-internal(href='/variant/tgv66359566#frequency') tgv66359566の例
+                    | )。Advanced searchの「Alternate allele frequency/count」では疾患および性別毎のアレル頻度を条件にバリアントを検索できます。
+              li
+                strong Datasets:
+                |  9,290人の日本人のアレル頻度およびgenotype countを
+                a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/ja/datasets/ncbn') NCBNデータセット
+                | として新たに追加しました（GRCh38のみ）。
+                ul.unordered-list
+                  li
+                    a.hyper-text.-external(href='https://ncbiobank.org/') ナショナルセンター・バイオバンクネットワーク(NCBN)
+                    | がサンプルの収集と全ゲノム解析を実施しました。
+                  li 日本人集団の頻度は
+                    a.hyper-text.-external(href='https://www.internationalgenome.org/') 国際1000ゲノムプロジェクト(1KGP)
+                    | の2,504人の頻度と比較できます。日本人集団と1KGPのジョイントコーリングが実施されました。
+                  li 頻度は各バリアントレポートページの「frequency」&gt; Dataset「NCBN」 &gt; Population「Total」を展開すると表示できます (
+                    a.hyper-text.-internal(href='/variant/tgv80918483#frequency') tgv80918483の例
+                    | )。Advanced searchの「Alternate allele frequency/count」では集団別の頻度を条件にバリアントを検索できます。
+          .release
+            h3.sectiontitle.heading 2024/2/28
+            ul.unordered-list.items
+              li
+                strong Simple/Advanced search:
+                |  #[a.hyper-text.-external(href='https://github.com/google-deepmind/alphamissense') AlphaMissense](
+                a.hyper-text.-external(href='https://www.science.org/doi/10.1126/science.adg7492') Cheng et al.2023
+                | )によるミスセンスバリアントの病原性予測結果を付与しました。
+              li
+                strong Datasets:
+                |  #[a.hyper-text.-external(href='https://gnomad.broadinstitute.org/') Genome Aggregation Database (gnomAD)]をバージョン4.0に更新しました。
+          .release
+            h3.sectiontitle.heading 2023/11/16
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  ToMMo 14KJPNをToMMo 54KJPN (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-54kjpn-20230626-af_snvindelall') ToMMo 54KJPN Allele Frequency Panel
+                | )に更新しました。
+              li
+                strong Advanced search:
+                |  バリアントID（例：tgv47264307(TogoVar)、rs671(dbSNP)）で検索可能になりました。
+              li
+                strong Downloads:
+                |  全バリアントのアレル頻度がこれまでのタブ区切り形式に加え、
+                a.hyper-text.-external(href='https://samtools.github.io/hts-specs/VCFv4.4.pdf')
+                  | VCF形式
+                | でダウンロードできるようになりました。
+          .release
+            h3.sectiontitle.heading 2023/7/14
+            ul.unordered-list.items
+              li
+                strong Simple/Advanced search:
+                |  検索結果をJSON、CSV、TSV形式でダウンロードできるようになりました。
+              li
+                strong Advanced search:
+                |  Add conditionに疾患名(Disease)を追加しました。
+                a.hyper-text.-external(href='https://www.ncbi.nlm.nih.gov/medgen/') MedGen
+                | の疾患名で検索できます。検索対象には疾患オントロジー
+                a.hyper-text.-external(href='https://monarchinitiative.org/') Mondo
+                | 上の下位概念の疾患も含まれます。
+          .release
+            h3.sectiontitle.heading 2022/11/1
+            ul.unordered-list.items
+              li
+                strong URL:
+                |  TogoVarのURLが
+                a.hyper-text.-external(href='https://togovar.biosciencedbc.jp') https://togovar.biosciencedbc.jp
+                | から
+                a.hyper-text.-internal(href='https://togovar.org') https://togovar.org
+                | に変わりました。
+              li
+                strong Simple/Advanced search:
+                |  GRCh38の位置でもバリアントを検索できるようになりました。引き続きGRCh37の位置でも検索できます。
+                ul.unordered-list
+                  li
+                    a.hyper-text.-internal(href='https://grch38.togovar.org') https://grch38.togovar.org
+                    |
+                    | (GRCh38)
+                  li
+                    a.hyper-text.-internal(href='https://grch37.togovar.org') https://grch37.togovar.org
+                    |
+                    | (GRCh37)
+              li
+                strong Downloads:
+                |  GRCh37に加え、GRCh38ベースのバリアントデータも一括ダウンロードできるようになりました。
+                ul.unordered-list
+                  li
+                    a.hyper-text.-internal(href='https://grch38.togovar.org/downloads/release/current/grch38/') https://grch38.togovar.org/downloads/release/current/grch38/
+                    |
+                    | (GRCh38)
+                  li
+                    a.hyper-text.-internal(href='https://grch37.togovar.org/downloads/release/current/grch37/') https://grch37.togovar.org/downloads/release/current/grch37/
+                    |
+                    | (GRCh37)
+              li
+                strong Misc:
+                |  TogoVarの提供者が
+                a.hyper-text.-external(href='https://biosciencedbc.jp') 国立研究開発法人科学技術振興機構 NBDC事業推進部
+                | から
+                a.hyper-text.-external(href='https://dbcls.rois.ac.jp') 大学共同利用機関法人 情報・システム研究機構 データサイエンス共同利用基盤施設ライフサイエンス統合データベースセンター（DBCLS）
+                | に変わりました。
+          .release
+            h3.sectiontitle.heading 2022/8/5
+            ul.unordered-list.items
+              li
+                strong Advanced search:
+                |  #[a.hyper-text.-internal(href='/?mode=advanced') Advanced search]を公開しました。
+              li
+                strong Gene page/Disease page:
+                |  1遺伝子（例：
+                a.hyper-text.-internal(href='/gene/8618') PAX4
+                |）および1疾患（例：
+                a.hyper-text.-internal(href='/disease/C0023467') Acute myeloid leukemia
+                |）に関連するバリアント情報のページを公開しました。
+              li
+                strong Variant page/Gene page/Disease page:
+                |  #[a.hyper-text.-external(href='https://www.ebi.ac.uk/gwas/') GWAS Catalog]に掲載されているゲノムワイド関連解析情報をバリアント、遺伝子、疾患のページに追加しました。
+              li
+                strong TogoVar API:
+                |  #[a.hyper-text.-internal(href='/api') TogoVar API version 0.91]を公開しました。
+          .release
+            h3.sectiontitle.heading 2021/12/16
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  ToMMo 4.7KJPNをToMMo 8.3KJPN (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-8.3kjpn-20200831-af_snvindelall') ToMMo 8.3KJPN Allele Frequency Panel
+                | )に更新しました。
+              li
+                strong Datasets:
+                |  ExACをgnomAD v2.1.1 (
+                a.hyper-text.-external(href='https://gnomad.broadinstitute.org/downloads') The Genome Aggregation Database
+                | )に更新しました。
+          .release
+            h3.sectiontitle.heading 2020/10/22
+            ul.unordered-list.items
+              li
+                strong Keyword search:
+                |  #[a.hyper-text.-external(target='_blank', href='https://varnomen.hgvs.org/') Human Genome Variation Society (HGVS) 表記](例：
+                a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:c.1510G&gt;A
+                | 、
+                a(target='_blank', href='/?term=ALDH2%3Ac.1510G%3EA') ALDH2:p.Glu504Lys
+                | )で検索可能になりました。
+          .release
+            h3.sectiontitle.heading 2020/7/27
+            ul.unordered-list.items
+              li
+                strong Datasets:
+                |  新たなデータセットとしてGEM-J WGA (
+                a(href='/doc/ja/datasets/gem_j_wga') GEM-Japan Whole Genome Aggregation
+                | )を追加し、ToMMo 3.5KJPNをToMMo 4.7KJPN (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-4.7kjpn-20190826-af_snvindelall') ToMMo 4.7KJPN Allele Frequency Panel
+                | )に更新しました。また、ClinVarも更新しました。
+              li
+                strong Usability:
+                |  Karyotypeによる検索ができるようになりました。
+          .release
+            h3.sectiontitle.heading 2019/7/25
+            ul.unordered-list.items
+              li
+                strong Keyword search:
+                |  HGNC Gene Symbolの別名（例：PD-1、p53）で検索できるようになりました。
+              li
+                strong Filters:
+                |  Alternate allele frequencyを検索条件にする場合に、検索対象としてユーザーが選択した「全てのDataset」または「いずれかのDataset」のどちらかを指定できるようになりました。
+              li
+                strong Filters:
+                |  Consequence、SIFT、Polyphenの値でファセット検索可能になりました。
+              li
+                strong Filters:
+                |  低品質のバリアントを非表示にできるようになりました。
+              li
+                strong Datasets:
+                |  ToMMo 3.5KJPNをVer.2 (
+                a.hyper-text.-external(href='https://jmorp.megabank.tohoku.ac.jp/downloads/tommo-ijgvd-3.5kjpnv1-af_snvindelall') ToMMo 3.5KJPNv2 Allele Frequency Panel
+                | )に更新しました。ClinVar、Variant Effect Predictor (VEP)も更新しました。詳細は
+                a(href='/doc/ja/datasets') Datasets
+                | を参照ください。
+              li
+                strong Usability:
+                |  Configurationメニューで表示項目の選択ができるようになりました。
+              li
+                strong Usability:
+                |  ユーザーインターフェースを改善して使いやすくしました。
+          .release
+            h3.sectiontitle.heading 2018/6/7
+            ul.unordered-list.items
+              li
+                | TogoVarの公開を開始しました。詳細は
+                a.hyper-text.-external(href='https://www.jst.go.jp/pr/announce/20180607/index.html') プレスリリース
+                | を参照ください。

--- a/app/frontend/views/doc/ja/history.pug
+++ b/app/frontend/views/doc/ja/history.pug
@@ -108,22 +108,22 @@ block content
                         a.hyper-text.-external(href='https://glycosmos.org/') 糖鎖科学ポータル GlyCosmos
                         | ）
                       li 疾患関連バリアント（情報源：UniProt）
-                li
-                  strong Variant/Gene page:
-                  |  新しい URL 形式がサポートされました。
-                  ul.unordered-list
-                    li 染色体番号、塩基位置、参照アレル、代替アレルによる指定
-                      ul.unordered-list
-                        li 例：
-                          a.hyper-text.-internal(href='/variant/12-111803962-G-A') https://grch38.togovar.org/variant/12-111803962-G-A
-                    li dbSNPのrs番号による指定
-                      ul.unordered-list
-                        li 例：
-                          a.hyper-text.-internal(href='/variant/rs671') https://grch38.togovar.org/variant/rs671
-                    li HGNC遺伝子シンボルによる指定
-                      ul.unordered-list
-                        li 例：
-                          a.hyper-text.-internal(href='/gene/ALDH2') https://grch38.togovar.org/gene/ALDH2
+              li
+                strong Variant/Gene page:
+                |  新しい URL 形式がサポートされました。
+                ul.unordered-list
+                  li 染色体番号、塩基位置、参照アレル、代替アレルによる指定
+                    ul.unordered-list
+                      li 例：
+                        a.hyper-text.-internal(href='/variant/12-111803962-G-A') https://grch38.togovar.org/variant/12-111803962-G-A
+                  li dbSNPのrs番号による指定
+                    ul.unordered-list
+                      li 例：
+                        a.hyper-text.-internal(href='/variant/rs671') https://grch38.togovar.org/variant/rs671
+                  li HGNC遺伝子シンボルによる指定
+                    ul.unordered-list
+                      li 例：
+                        a.hyper-text.-internal(href='/gene/ALDH2') https://grch38.togovar.org/gene/ALDH2
           .release
             h3.sectiontitle.heading
               span.date 2024/12/3


### PR DESCRIPTION
## 概要

このPRでは、Advanced Search のURL共有処理について、短い検索条件では不要な圧縮処理を行わないように調整しました。

あわせて、Gene/Variant report の Stanza 設定と、HistoryページのHTML構造・スタイルを整理しています。

## 主な変更内容

### Advanced Search URL共有処理の調整

- Advanced Search の検索条件URL生成時に、従来形式の `q` が十分短い場合は圧縮処理を行わず、そのまま `q` を使用するようにしました。
- 長い検索条件の場合のみ、圧縮形式の `qz` と比較して短い方を使用します。
- この仕様に合わせて、`AGENTS.md` の Advanced Search URL共有に関する説明を更新しました。

### Stanza設定の更新

- `variant-transcript` Stanza に `assembly` を渡すようにしました。
- 既存の参照ゲノム設定に合わせて、`$TOGOVAR_FRONTEND_REFERENCE` を使用しています。

### Historyページの構造とスタイル整理

- Historyページの各リリース項目を `.release` で括る構造に変更しました。
- `h3.heading` と `ul.items` を1リリース単位でまとめ、HTML構造上も日付と内容の対応が分かりやすくなるようにしました。
- 区切り線・余白・日付表示を `.release` 単位で整理しました。
- `unordererd-list` になっていた typo を `unordered-list` に修正しました。
- 日本語版Historyページで、`Variant/Gene page` の `li` が誤って `Gene page` の子要素になっていたインデントを修正しました。